### PR TITLE
fix: use GITHUB_TOKEN instead of PAT_TOKEN in changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Changesets
         uses: shunkakinoki/actions/.github/actions/changesets@279799c0e7f638b159ebe148fb729e63af6b08bc
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           publish-command: 'bun run publish'
           create-github-releases: 'true'


### PR DESCRIPTION
## Changes Made
- Replaced `secrets.PAT_TOKEN` with `secrets.GITHUB_TOKEN` in changesets workflow
- Simplifies authentication for the changesets GitHub action
- Reduces dependency on custom Personal Access Tokens

## Technical Details
- Updated `.github/workflows/changesets.yml` to use standard GitHub token
- This change improves security by using the built-in workflow permissions
- No breaking changes to the workflow functionality

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Build and test suites pass successfully
- Workflow configuration validated for syntax correctness
- No impact on existing CI/CD pipeline

🤖 Generated with Cursor