### PR TITLE
fix: add Setup Bun step to changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: shunkakinoki/actions/.github/actions/setup-bun@279799c0e7f638b159ebe148fb729e63af6b08bc
       - name: Run Changesets
         uses: shunkakinoki/actions/.github/actions/changesets@279799c0e7f638b159ebe148fb729e63af6b08bc
         with:


### PR DESCRIPTION
## Changes Made
- Added Setup Bun step before running changesets to ensure proper environment
- Ensures Bun runtime is available for changesets operations

## Technical Details
- Added setup-bun action before the changesets action in the workflow
- Uses the same Bun setup action already used in other workflow steps
- Ensures consistent environment setup across all changesets operations

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All pre-push checks pass (build and test)
- Workflow syntax is valid and follows existing patterns
- No breaking changes to existing functionality

🤖 Generated with Grok