### PR TITLE
chore: make docs and landing apps private

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-composer/docs",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port $(microfrontends port)",
     "dev:proxy": "microfrontends proxy --local-apps docs",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-composer/landing",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port $(microfrontends port)",
     "dev:proxy": "microfrontends proxy --local-apps landing",


### PR DESCRIPTION
## Changes Made
- Set `private: true` in apps/docs/package.json
- Set `private: true` in apps/landing/package.json

## Technical Details
- Prevents accidental publishing of internal apps to npm registry
- Configuration change only, no code modifications
- Both apps are internal documentation/landing pages

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All tests pass successfully
- Build completes without errors
- No breaking changes to existing functionality

🤖 Generated with grok-code-fast-1