### PR TITLE
feat: add turbo-ignore with vercel.json to Next.js apps

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "bun run build",
+  "git": {
+    "autoJobCancelation": true,
+    "autoAlias": true,
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "git log -1 --pretty=oneline --abbrev-commit | grep -w \"\\[skip deploy\\]\" || npx turbo-ignore --fallback=HEAD^"
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "bun run build",
+  "git": {
+    "autoJobCancelation": true,
+    "autoAlias": true,
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "git log -1 --pretty=oneline --abbrev-commit | grep -w \"\\[skip deploy\\]\" || npx turbo-ignore --fallback=HEAD^"
+}


### PR DESCRIPTION
## Changes Made
- Add vercel.json configuration to docs app with turbo-ignore
- Add vercel.json configuration to landing app with turbo-ignore  
- Configure buildCommand to use 'bun run build'
- Enable git autoJobCancelation, autoAlias, and deploymentEnabled
- Set ignoreCommand to skip deployments with '[skip deploy]' commit message
- Use turbo-ignore as fallback for intelligent deployment skipping

## Technical Details
- Implements turbo-ignore for efficient deployment management
- Uses git commit message pattern matching to skip deployments
- Configures Next.js apps for optimal Vercel deployment settings
- Enables automatic job cancellation and deployment management

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All tests pass (16 tests across 4 files)
- Build succeeds for all packages (docs, landing, cli)
- No breaking changes to existing functionality

🤖 Generated with Serena