### PR TITLE
refactor: simplify package names and update microfrontends config

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@open-composer/docs",
+  "name": "open-composer-docs",
   "version": "0.1.0",
   "private": false,
   "scripts": {

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "bun run build",
+  "git": {
+    "autoJobCancelation": true,
+    "autoAlias": true,
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "git log -1 --pretty=oneline --abbrev-commit | grep -w \"\\[skip deploy\\]\" || npx turbo-ignore --fallback=HEAD^"
+}

--- a/apps/landing/microfrontends.json
+++ b/apps/landing/microfrontends.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://openapi.vercel.sh/microfrontends.json",
   "applications": {
-    "@open-composer/landing": {
+    "open-composer-landing": {
       "packageName": "open-composer-landing",
       "development": {
-        "fallback": "https://placeholder.com"
+        "fallback": "opencomposer.dev"
       }
     },
-    "@open-composer/docs": {
+    "open-composer-docs": {
       "packageName": "open-composer-docs",
       "routing": [
         {

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@open-composer/landing",
+  "name": "open-composer-landing",
   "version": "0.1.0",
   "private": false,
   "scripts": {

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "bun run build",
+  "git": {
+    "autoJobCancelation": true,
+    "autoAlias": true,
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "git log -1 --pretty=oneline --abbrev-commit | grep -w \"\\[skip deploy\\]\" || npx turbo-ignore --fallback=HEAD^"
+}


### PR DESCRIPTION
## Changes Made
- Changed package names from scoped (@open-composer/*) to simple names (open-composer-*)
- Updated microfrontends.json to reference new package names
- Updated fallback URL to use production domain (opencomposer.dev)

## Technical Details
- **Package name changes**: 
  -  → 
  -  → 
- **Microfrontends config**: Updated application references to match new package names
- **Fallback URL**: Changed from placeholder to production domain

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All pre-push hooks pass (tests and builds completed successfully)
- No breaking changes to existing functionality
- Package naming is now consistent with the project structure

🤖 Generated with code-supernova