### PR TITLE
chore: remove buildCommand from vercel.json files

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "bun run build",
   "git": {
     "autoJobCancelation": true,
     "autoAlias": true,

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "bun run build",
   "git": {
     "autoJobCancelation": true,
     "autoAlias": true,


### PR DESCRIPTION
Remove explicit buildCommand from docs and landing app vercel.json files to use Vercel's default build behavior.

🤖 Generated with Serena