### PR TITLE
chore: update changesets workflow and git-worktrees package config

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,7 +37,7 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           publish-command: 'bun run publish'
           create-github-releases: 'true'
-          commit-mode: 'github-api'
+          commit-mode: 'git-cli'
   changesets-pull-request:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/packages/git-worktrees/package.json
+++ b/packages/git-worktrees/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@open-composer/git-worktrees",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Changes Made
- Changed changesets workflow commit mode from 'github-api' to 'git-cli' for better compatibility
- Added publishConfig with public access to git-worktrees package for proper publishing

## Technical Details
- Updated changesets workflow to use git-cli commit mode instead of github-api
- Added public publish configuration to git-worktrees package.json for proper NPM publishing

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All pre-push hooks pass (build and test suites)
- Changes are backward compatible and don't affect existing functionality

🤖 Generated with Cursor