### PR TITLE
fix: update changesets workflow to use PAT_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Changesets
         uses: shunkakinoki/actions/.github/actions/changesets@36c30e5cf16d45445c026abf8f71a437443cbd33
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           publish-command: 'bun run publish'
           create-github-releases: 'true'


### PR DESCRIPTION
## Changes Made
- Updated changesets workflow to use PAT_TOKEN instead of GITHUB_TOKEN
- This provides better permissions for automated releases and package publishing

## Technical Details
- Modified .github/workflows/changesets.yml to use PAT_TOKEN
- Ensures proper authentication for npm publishing operations
- Maintains compatibility with existing workflow structure

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Pre-push hooks pass (build and tests successful)
- Workflow configuration validated for syntax correctness
- No breaking changes to existing CI/CD pipeline

🤖 Generated with grok-code-fast-1