### PR TITLE
fix: add custom publish script to prevent 413 payload too large error

### DIFF
--- a/.changeset/tender-months-guess.md
+++ b/.changeset/tender-months-guess.md
@@ -1,0 +1,5 @@
+---
+"open-composer": patch
+---
+
+Add publish cmd

--- a/.changeset/tender-months-guess.md
+++ b/.changeset/tender-months-guess.md
@@ -2,4 +2,4 @@
 "open-composer": patch
 ---
 
-Add publish cmd
+Fix 413 Payload Too Large error with custom publish script

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,6 +13,7 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target=node",
     "dev": "bun run ./src/index.ts",
     "prepublishOnly": "bun run scripts/prepublish.ts",
+    "publish": "bun run scripts/publish.ts",
     "type-check": "tsc --noEmit",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,7 @@
       "outputs": []
     },
     "prepublishOnly": {
-      "dependsOn": ["^prepublishOnly"]
+      "dependsOn": ["^build", "^prepublishOnly"]
     }
   },
   "globalEnv": [


### PR DESCRIPTION
## Changes Made
- Remove files field from CLI package.json to allow custom publish script
- Add publish script that uses scripts/publish.ts instead of changeset publish
- Update turbo.json to ensure build happens before prepublishOnly
- Add changeset for patch release

## Technical Details
- The custom publish script properly handles platform-specific binary packages separately
- Prevents npm 413 Payload Too Large errors by not including large dist/ binaries in main package
- Uses proper multi-package publishing workflow with optionalDependencies

## Testing
- All pre-commit hooks pass (Biome formatting, lefthook validation)
- All pre-push hooks pass (build and test)
- Changeset workflow will use custom publish script instead of default

🤖 Generated with Cursor