### PR TITLE
fix: prevent prepublish script from publishing main package during Changesets

### DIFF
--- a/apps/cli/scripts/prepublish.ts
+++ b/apps/cli/scripts/prepublish.ts
@@ -165,25 +165,27 @@ for (const [os, arch] of targets) {
       ),
     );
 
-  // -------------------------------------------------------------------------
-  // Publish the binaries
-  // -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Publish the binaries
+    // -------------------------------------------------------------------------
 
-  for (const [name] of Object.entries(binaries)) {
-    await $`cd dist/${name} && bun publish --access public --tag latest`;
-  }
+    for (const [name] of Object.entries(binaries)) {
+      await $`cd dist/${name} && bun publish --access public --tag latest`;
+    }
 
-  // -------------------------------------------------------------------------
-  // Publish the main package (only when NOT run by Changesets)
-  // -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Publish the main package (only when NOT run by Changesets)
+    // -------------------------------------------------------------------------
 
-  // Skip publishing the main package if RELEASE_OPENCOMPOSER_BINS is set
-  // This indicates we're running in Changesets, which will handle the main package
-  if (!process.env.RELEASE_OPENCOMPOSER_BINS) {
-    await $`cd ./dist/opencomposer && bun publish --access public --tag latest`;
-  } else {
-    console.log('Skipping main package publish - RELEASE_OPENCOMPOSER_BINS is set, letting Changesets handle it');
-  }
+    // Skip publishing the main package if RELEASE_OPENCOMPOSER_BINS is set
+    // This indicates we're running in Changesets, which will handle the main package
+    if (!process.env.RELEASE_OPENCOMPOSER_BINS) {
+      await $`cd ./dist/opencomposer && bun publish --access public --tag latest`;
+    } else {
+      console.log(
+        "Skipping main package publish - RELEASE_OPENCOMPOSER_BINS is set, letting Changesets handle it",
+      );
+    }
   }
 }
 

--- a/apps/cli/scripts/prepublish.ts
+++ b/apps/cli/scripts/prepublish.ts
@@ -165,19 +165,25 @@ for (const [os, arch] of targets) {
       ),
     );
 
-    // -------------------------------------------------------------------------
-    // Publish the binaries
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Publish the binaries
+  // -------------------------------------------------------------------------
 
-    for (const [name] of Object.entries(binaries)) {
-      await $`cd dist/${name} && bun publish --access public --tag latest`;
-    }
+  for (const [name] of Object.entries(binaries)) {
+    await $`cd dist/${name} && bun publish --access public --tag latest`;
+  }
 
-    // -------------------------------------------------------------------------
-    // Publish the package
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Publish the main package (only when NOT run by Changesets)
+  // -------------------------------------------------------------------------
 
+  // Skip publishing the main package if RELEASE_OPENCOMPOSER_BINS is set
+  // This indicates we're running in Changesets, which will handle the main package
+  if (!process.env.RELEASE_OPENCOMPOSER_BINS) {
     await $`cd ./dist/opencomposer && bun publish --access public --tag latest`;
+  } else {
+    console.log('Skipping main package publish - RELEASE_OPENCOMPOSER_BINS is set, letting Changesets handle it');
+  }
   }
 }
 


### PR DESCRIPTION
## Changes Made
- Modified prepublish.ts to skip publishing the main package when RELEASE_OPENCOMPOSER_BINS is set
- This prevents conflicts between the prepublish script and Changesets publish action
- Changesets will handle publishing the main package itself

## Technical Details
- Added environment variable check for RELEASE_OPENCOMPOSER_BINS in prepublish.ts
- When this variable is set (as it is in the Changesets workflow), the script skips the main package publish step
- The script still publishes individual binary packages as intended
- Added logging to indicate when main package publishing is skipped

## Testing
- All pre-commit hooks pass (Biome formatting, linting, TypeScript checks)
- The fix prevents the 403 Forbidden error that was occurring during Changesets publishing

🤖 Generated with Claude