### PR TITLE
fix: resolve Windows postinstall and CI install race condition

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -37,8 +37,12 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag || github.ref }}
       - name: Setup Node.js
         uses: actions/setup-node@v5
-      - name: Install open-composer globally
-        run: npm install -g ${{ github.event.release.tag_name || github.event.inputs.tag || 'open-composer@latest' }}
+      - name: Install open-composer globally with retry
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 30
+          max_attempts: 3
+          command: npm install -g ${{ github.event.release.tag_name || github.event.inputs.tag || 'open-composer@latest' }}
       - name: Verify opencomposer command
         run: open-composer --version
         shell: bash

--- a/apps/cli/scripts/postinstall.mjs
+++ b/apps/cli/scripts/postinstall.mjs
@@ -14,11 +14,11 @@ const require = createRequire(import.meta.url);
 // -----------------------------------------------------------------------------
 
 function findBinary() {
-  const platform = os.platform() === "win32" ? "windows" : os.platform();
+  const platform = os.platform();
   const arch = os.arch();
   const binaryDirName = `cli-${platform}-${arch}`;
   const packageName = `@open-composer/${binaryDirName}`;
-  const binary = platform === "windows" ? "opencomposer.exe" : "opencomposer";
+  const binary = platform === "win32" ? "opencomposer.exe" : "opencomposer";
 
   try {
     // Use require.resolve to find the package


### PR DESCRIPTION
## Changes Made
- Fix platform naming mismatch in postinstall.mjs (win32 vs windows)
- Add retry logic to install workflow for npm package availability
- Align platform naming with prepublish.ts package generation
- Fix @open-composer/cli-win32-x64 package resolution on Windows
- Handle race condition between npm publish and install CI

## Technical Details
- Removed incorrect win32 to windows conversion in postinstall script
- Added retry mechanism using nick-fields/retry action for install workflow
- Platform detection now uses raw os.platform() values consistently
- Binary naming now matches package naming conventions

## Testing
- All pre-commit hooks pass (Biome formatting, lefthook validation)
- All tests pass across all packages (turbo build & test successful)
- Manual testing confirms Windows binary resolution works
- CI install workflow now handles npm publishing delays gracefully

🤖 Generated with Cursor