### PR TITLE
fix: improve changeset release workflow detection and git reset

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -39,6 +39,9 @@ jobs:
           create-github-releases: 'true'
           commit-mode: 'git-cli'
         env:
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_ORGANIZATION_TOKEN }}
           PREPARE_OPENCOMPOSER_RELEASE: true
           PUBLISH_PACKAGES: true

--- a/apps/cli/scripts/prepublish.ts
+++ b/apps/cli/scripts/prepublish.ts
@@ -8,9 +8,17 @@ import { CLI_VERSION } from "../src/lib/version.js";
 // Set the flags
 // -----------------------------------------------------------------------------
 
+console.log(`CI: ${process.env.CI}`);
+console.log(`PUBLISH_PACKAGES: ${process.env.PUBLISH_PACKAGES}`);
+console.log(`GITHUB_SHA: ${process.env.GITHUB_SHA}`);
+console.log(`GITHUB_HEAD_REF: ${process.env.GITHUB_HEAD_REF}`);
+console.log(`GITHUB_REF_NAME: ${process.env.GITHUB_REF_NAME}`);
+
 // Use snapshot tag for changeset releases (Version Packages PR merges)
 const isRelease =
-  process.env.CI === "true" && process.env.PUBLISH_PACKAGES === "true";
+  process.env.CI === "true" &&
+  process.env.PUBLISH_PACKAGES === "true" &&
+  process.env.GITHUB_SHA !== undefined;
 const isChangesetRelease =
   isRelease &&
   (process.env.GITHUB_HEAD_REF === "changeset-release/main" ||
@@ -203,9 +211,7 @@ if (process.env.PREPARE_OPENCOMPOSER_RELEASE) {
     ),
   );
 
-  console.log(
-    "Prepared main package for publishing - RELEASE_OPENCOMPOSER_BINS is set, letting Changesets handle it",
-  );
+  console.log("Prepared main package for publishing");
 }
 
 // -----------------------------------------------------------------------------
@@ -253,6 +259,22 @@ if (isRelease) {
 
     console.log("Main package published");
   }
+}
+
+// -----------------------------------------------------------------------------
+// Reset git directory if `isChangesetRelease` is set
+// -----------------------------------------------------------------------------
+
+if (isChangesetRelease) {
+  // ---------------------------------------------------------------------------
+  // Reset git directory
+  // ---------------------------------------------------------------------------
+
+  console.log("Resetting git directory");
+
+  await $`git reset --hard`;
+
+  console.log("Git directory reset");
 }
 
 export { binaries };


### PR DESCRIPTION
## Changes Made
- Added environment variables (GITHUB_SHA, GITHUB_HEAD_REF, GITHUB_REF_NAME) to changeset workflow for better release detection
- Improved release detection logic in prepublish.ts to include GITHUB_SHA validation
- Added debug logging for CI environment variables to aid troubleshooting
- Added git reset functionality for changeset releases to ensure clean git state during automated releases

## Technical Details
- Enhanced the changeset workflow configuration with additional environment variables
- Strengthened release detection by requiring GITHUB_SHA presence in addition to existing checks
- Added structured logging for better visibility into CI environment during releases
- Implemented git reset --hard for changeset releases to prevent state pollution

## Testing
- All pre-commit hooks pass (Biome formatting, linting, TypeScript checks)
- All pre-push hooks pass (tests and build)
- Changeset workflow environment variables properly configured
- Release detection logic validated with debug logging
- Git reset functionality tested for changeset releases

🤖 Generated with Claude