### PR TITLE
fix: update changeset action to latest SHA

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PUBLISH_PACKAGES: true
       - name: Run Changesets
-        uses: shunkakinoki/actions/.github/actions/changesets@0938f5255ef4c8291067fa104c6030791f84450f
+        uses: shunkakinoki/actions/.github/actions/changesets@fbd9749bb500885ae9709fec43ed14016b0b928f
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_ORGANIZATION_TOKEN }}


### PR DESCRIPTION
## Changes Made
- Updated changeset action reference from SHA 0938f5255ef4c8291067fa104c6030791f84450f to fbd9749bb500885ae9709fec43ed14016b0b928f

## Technical Details
- Updated the GitHub Actions workflow to use the latest changeset action SHA
- Ensures compatibility with the latest action features and bug fixes

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- All tests pass across all packages (agent-router, git, git-stack, git-worktrees, posthog-worker, CLI)
- All builds successful (packages and Next.js apps)
- No breaking changes to existing functionality

🤖 Generated with Claude