### PR TITLE
chore: update changesets action to latest version

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PUBLISH_PACKAGES: true
       - name: Run Changesets
-        uses: shunkakinoki/actions/.github/actions/changesets@fbd9749bb500885ae9709fec43ed14016b0b928f
+        uses: shunkakinoki/actions/.github/actions/changesets@32b69faae6a02cb50f07fb8d072fa2682d4df893
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_ORGANIZATION_TOKEN }}


### PR DESCRIPTION
## Changes Made
- Updated changesets action commit hash from fbd9749 to 32b69fa
- Ensures latest changesets functionality and security updates

## Technical Details
- Updated GitHub Actions workflow in .github/workflows/changesets.yml
- Changesets action now uses latest commit for improved reliability
- Maintains existing workflow structure and functionality

## Testing
- All pre-commit hooks pass (Biome formatting, lefthook validation)
- Pre-push hooks pass (build and test suites successful)
- No breaking changes to existing CI/CD pipeline
- Manual verification of workflow syntax and structure

🤖 Generated with Cursor