### PR TITLE
fix: export GitHub environment variables in push workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "PUBLISH_PACKAGES=${PUBLISH_PACKAGES}" >> $GITHUB_ENV
+          echo "GITHUB_SHA=${{ github.sha }}" >> $GITHUB_ENV
+          echo "GITHUB_REF=${{ github.ref }}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+          echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
+          echo "GITHUB_EVENT_PATH=${{ github.event_path }}" >> $GITHUB_ENV
+          echo "GITHUB_EVENT_NUMBER=${{ github.event_number }}" >> $GITHUB_ENV
+          echo "GITHUB_REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
         env:
           PUBLISH_PACKAGES: true
       - name: Run Changesets


### PR DESCRIPTION
## Changes Made
- Add GITHUB_SHA and other environment variables to changesets-publish job
- Fix prepublish.ts undefined environment variables issue  
- Ensure proper release detection in CI/CD pipeline

## Technical Details
The custom Changesets action only exports environment variables on pull request events, but the push workflow also needs these variables for the prepublish script to correctly detect releases.

## Testing
- Pre-commit hooks pass (Biome formatting, linting, build, test)
- No breaking changes to existing functionality

🤖 Generated with Cursor