### PR TITLE
feat: improve changeset release workflow detection

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,6 +30,13 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Bun
         uses: shunkakinoki/actions/.github/actions/setup-bun@36c30e5cf16d45445c026abf8f71a437443cbd33
+      - name: Detect if Changeset Release
+        run: |
+          if [ "${{ github.head_ref }}" = "changeset-release/main" ] || [ "${{ github.ref_name }}" = "changeset-release/main" ]; then
+            echo "CHANGESET_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "CHANGESET_RELEASE=false" >> $GITHUB_ENV
+          fi
       - name: Set Environment Variables
         run: |
           echo "PUBLISH_PACKAGES=${PUBLISH_PACKAGES}" >> $GITHUB_ENV
@@ -44,10 +51,11 @@ jobs:
         env:
           PUBLISH_PACKAGES: true
       - name: Run Changesets
-        uses: shunkakinoki/actions/.github/actions/changesets@32b69faae6a02cb50f07fb8d072fa2682d4df893
+        uses: shunkakinoki/actions/.github/actions/changesets@9506b99db7f595bd28dc7e27d22d7f3f6297334a
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_ORGANIZATION_TOKEN }}
+          version-command: ${{ env.CHANGESET_RELEASE == 'true' && 'bun run version' || 'bun run version:snapshot' }}
           publish-command: 'bun run publish'
           create-github-releases: 'true'
           commit-mode: 'git-cli'

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -8,8 +8,7 @@
         "PUBLISH_PACKAGES",
         "RELEASE_OPENCOMPOSER_ZIPS",
         "GITHUB_SHA",
-        "GITHUB_HEAD_REF",
-        "GITHUB_REF_NAME"
+        "CHANGESET_RELEASE"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "turbo test",
     "prepublishOnly": "turbo run prepublishOnly",
     "publish": "turbo run prepublishOnly && changeset publish",
+    "version": "changeset version",
+    "version:snapshot": "changeset version --snapshot",
     "changeset:status": "changeset status --verbose --since origin/main",
     "check": "biome check .",
     "check:fix": "biome check --write --unsafe .",


### PR DESCRIPTION
## Changes Made
- Add CHANGESET_RELEASE environment variable detection in GitHub Actions workflow
- Simplify prepublish script logic using CHANGESET_RELEASE flag instead of multiple environment variables
- Add version and version:snapshot scripts to package.json for changeset management
- Update turbo configuration to pass CHANGESET_RELEASE environment variable
- Remove redundant git reset logic from prepublish script

## Technical Details
- Enhanced GitHub Actions workflow with better changeset detection logic
- Streamlined prepublish script by consolidating environment variable checks
- Added changeset version commands for both regular and snapshot releases
- Improved turbo configuration for consistent environment variable passing
- Removed unnecessary git directory reset operations

## Testing
- All pre-commit hooks pass (Biome formatting, linting, type checking)
- All pre-push hooks pass (test suite and build verification)
- Changeset workflow improvements verified through CI pipeline
- No breaking changes to existing release process

🤖 Generated with Claude