### PR TITLE
ci: allow release jobs to be skipped in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: release-upload,release-latest


### PR DESCRIPTION
## Changes Made
- Add allowed-skips configuration for release-upload and release-latest jobs in alls-green action
- Enables more flexible CI pipeline execution by allowing specific release jobs to be skipped when appropriate

## Technical Details
- Modified .github/workflows/release.yml to include allowed-skips parameter
- The alls-green action now permits release-upload and release-latest jobs to be skipped
- Improves workflow reliability by allowing graceful handling of optional release steps

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Pre-push hooks successful (build and test suites pass)
- Turbo build completes successfully across all packages
- All automated tests pass (18 tests across packages)
- No breaking changes to existing workflow functionality

🤖 Generated with Grok