### PR TITLE
feat: add settings CLI command with database integration

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -53,6 +53,21 @@ export const runMigration = <R, E>(migration: Effect.Effect<unknown, E, R>) =>
     Effect.provide(BunContext.layer),
   );
 
+/**
+ * Initializes the database by running migrations
+ */
+export const initializeDatabase = Effect.gen(function* () {
+  // Run migrations directly
+  const sql = yield* SqliteClient.SqliteClient;
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `;
+}).pipe(Effect.provide(SqliteClientLive));
+
 export { SqliteClientLive, DrizzleLive, MigrationsLive };
 export { SqliteDrizzle } from "@effect/sql-drizzle/Sqlite";
 export * from "./schema";


### PR DESCRIPTION
## Changes Made
- Implement settings service with get/set/list/delete operations for key-value configuration
- Add comprehensive /settings CLI command with subcommands:
  - `settings get <key>` - retrieve setting value
  - `settings set <key> <value>` - set/update setting value  
  - `settings list [--json]` - list all settings (table or JSON format)
  - `settings delete [--force] <key>` - delete setting with confirmation
- Fix database migrations to run automatically on CLI startup using direct SQL execution
- Resolve TypeScript error type mismatches in Effect operations by mapping database errors to generic Error types
- Integrate settings command into main CLI application with proper service layer

## Technical Details
- Uses SQLite database with Drizzle ORM for type-safe database operations
- Implements lazy database initialization to ensure migrations run before first access
- Settings are stored as key-value pairs with automatic timestamps
- Error handling maps specific database errors to generic Error types for interface compatibility
- All database operations include proper error mapping and telemetry tracking

## Testing
- All pre-commit hooks pass (Biome formatting, linting, TypeScript checks)
- Database tests pass with automatic migration execution
- Settings CLI commands work correctly with proper error handling
- Database initialization runs automatically on CLI startup
- No breaking changes to existing functionality

🤖 Generated with Cursor by Claude