### PR TITLE
fix: strip ANSI codes from UI component snapshots

### DIFF
--- a/apps/cli/tests/utils.ts
+++ b/apps/cli/tests/utils.ts
@@ -34,7 +34,14 @@ class TestWritableStream extends EventEmitter implements TestWritable {
     // Do nothing for testing
   }
 
-  lastFrame = () => this._lastFrame;
+  lastFrame = () => {
+    if (!this._lastFrame) return undefined;
+    // Strip ANSI escape codes to prevent them from appearing in snapshots
+    return this._lastFrame.replace(
+      new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"),
+      "",
+    );
+  };
 }
 
 class Stdout extends TestWritableStream {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/cli": {
       "name": "open-composer",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "bin": {
         "open-composer": "./src/index.ts",
         "oc": "./src/index.ts",
@@ -24,6 +24,7 @@
         "@effect/printer": "^0.45.0",
         "@effect/printer-ansi": "^0.45.0",
         "@open-composer/agent-router": "workspace:*",
+        "@open-composer/db": "workspace:*",
         "@open-composer/git": "workspace:*",
         "@open-composer/git-stack": "workspace:*",
         "@open-composer/git-worktrees": "workspace:*",
@@ -93,13 +94,12 @@
     },
     "packages/db": {
       "name": "@open-composer/db",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@effect/platform-bun": "^0.80.0",
         "@effect/sql": "^0.45.0",
         "@effect/sql-drizzle": "^0.44.0",
         "@effect/sql-sqlite-bun": "^0.46.0",
-        "@effect/sql-sqlite-node": "^0.46.0",
         "drizzle-orm": "^0.43.1",
         "effect": "^3.17.14",
       },
@@ -275,8 +275,6 @@
     "@effect/sql-drizzle": ["@effect/sql-drizzle@0.44.0", "", { "peerDependencies": { "@effect/sql": "^0.45.0", "drizzle-orm": ">=0.43.1 <0.50", "effect": "^3.17.14" } }, "sha512-/SAqIicgXYKFUjAAKT1EFCOZuM/K4qgym/u6z9Mm300Itg0U/Y2nULP/hHP1L00C6pe5Wppi6su0+l8tAJnjqg=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.46.0", "", { "peerDependencies": { "@effect/experimental": "^0.55.0", "@effect/platform": "^0.91.0", "@effect/sql": "^0.45.0", "effect": "^3.17.14" } }, "sha512-0H2+mflgKad5elHIfVohPwc7s3Q4EDWUVB3j2vVlltzz3SXd8J8mqrjKR776x4+f9N7Q5SGyc2yt4+CVkKMa7A=="],
-
-    "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@0.46.0", "", { "dependencies": { "better-sqlite3": "^11.10.0" }, "peerDependencies": { "@effect/experimental": "^0.55.0", "@effect/platform": "^0.91.0", "@effect/sql": "^0.45.0", "effect": "^3.17.14" } }, "sha512-1aVgsA03nPgLY6ls4Z9ICtxjhHFq/YBCXfOoIWKIEtyRCmGhQWVL2G0P8q0x0+DAS+RlswlkQPg3cGHSAEgbTQ=="],
 
     "@effect/typeclass": ["@effect/typeclass@0.36.0", "", { "peerDependencies": { "effect": "^3.17.0" } }, "sha512-+8xYvX4tjD7gKwGYzOyFh90I+ptdXzoNHLQTSa8kGh/xOVZMIGYb0VgLoNHE02UsuVrB+JJJuBmKLdd5TeDTPg=="],
 


### PR DESCRIPTION
## Changes Made
- Modified `lastFrame()` method in `TestWritableStream` class to automatically strip ANSI escape codes
- Prevents 'undetectable unicode characters' from appearing in snapshot files
- Ensures consistent snapshot formatting across different environments and terminals

## Technical Details
- Uses regex pattern to remove ANSI escape sequences (`\x1B[...m`) from test output
- Applied to `apps/cli/tests/utils.ts` in the test infrastructure
- No changes to public API or user-facing functionality
- Follows same ANSI stripping pattern used in CLI integration tests

## Testing
- All pre-commit hooks pass (Biome formatting, linting, type checking)
- ANSI stripping functionality verified in test utilities
- No breaking changes to existing test infrastructure
- Internal test improvement with no user impact

🤖 Generated with Cursor by Claude