### PR TITLE
feat: add CLI help text snapshot test

### DIFF
--- a/apps/cli/tests/__snapshots__/cli.test.tsx.snap
+++ b/apps/cli/tests/__snapshots__/cli.test.tsx.snap
@@ -1,0 +1,23 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`CLI Execution prints help text that matches snapshot 1`] = `
+"Open Composer CLI
+
+USAGE
+  $ open-composer <command>
+
+COMMANDS
+  agents            Manage AI agents
+  pr                Manage GitHub Pull Requests with comprehensive workflow
+  gw                Manage git worktrees
+  sessions          Manage development sessions
+  settings          Manage application settings
+  spawn             Spawn multiple AI agents in separate worktrees with tmux sessions
+  stack             Manage stacked pull requests
+  status            Show current status of agents, worktrees, and PRs
+  telemetry         Manage telemetry and privacy settings
+  tui               Launch the interactive TUI
+
+Run 'open-composer <command> --help' for more information on a specific command.
+"
+`;

--- a/apps/cli/tests/cli.test.tsx
+++ b/apps/cli/tests/cli.test.tsx
@@ -56,6 +56,16 @@ describe("CLI Execution", () => {
     expect(stdout).toContain("Manage AI agents");
   });
 
+  it("prints help text that matches snapshot", async () => {
+    const result = await runCli();
+    const stdout = stripAnsi(result.stdout);
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toMatchSnapshot();
+  });
+
   it("launches the TUI when requested", async () => {
     await new Promise<void>((resolve, reject) => {
       const child = spawn("bun", ["run", cliPath, "tui"], {


### PR DESCRIPTION
## Changes Made
- Added test to verify CLI help output matches snapshot
- Generate snapshot file with expected help text output  
- Ensure CLI help text remains consistent across changes

## Technical Details
- Added snapshot test in `apps/cli/tests/cli.test.tsx`
- Generated snapshot file `apps/cli/tests/__snapshots__/cli.test.tsx.snap`
- Test verifies help text output matches expected format
- Uses Bun's snapshot testing functionality

## Testing
- All pre-commit hooks pass (Biome formatting, linting, TypeScript checks)
- 174 tests pass across all packages
- Build completes successfully for all components
- Manual verification of CLI help output

🤖 Generated with Cursor by Claude