### PR TITLE
fix: update auto-merge workflow to use PAT_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: shunkakinoki/actions/.github/actions/auto-merge@156beb8dbd9b84135a994da9ea77398d91e33df6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
   auto-merge-check:
     if: always()


### PR DESCRIPTION
## Changes Made\n\nUpdated the auto-merge GitHub Actions workflow to use PAT_TOKEN instead of GITHUB_TOKEN for improved permissions when handling Dependabot PRs.\n\n## Technical Details\n\nIn [.github/workflows/auto-merge.yml](https://github.com/shunkakinoki/open-composer/blob/fix/auto-merge-token/.github/workflows/auto-merge.yml), changed:\n\n\n\nto:\n\n\n\nThis ensures the workflow has sufficient permissions for auto-merge operations.\n\n## Testing\n\n- Pre-push hooks ran successfully: All tests (191 passed) and build completed without issues.\n- No runtime tests needed for workflow configuration, but the change is minimal and targeted.\n\n🤖 Generated with Cursor by Grok