### PR TITLE
fix: correct microfrontend configuration spacing

### DIFF
--- a/apps/landing/microfrontends.json
+++ b/apps/landing/microfrontends.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/microfrontends.json",
   "applications": {
-    "open-composer-landing  ": {
+    "open-composer-landing": {
       "packageName": "open-composer-landing",
       "development": {
         "fallback": "opencomposer.dev"


### PR DESCRIPTION
## Summary
- Fix spacing issue in microfrontend configuration that was causing application name mismatch
- Update `open-composer-landing  ` to `open-composer-landing` (removed extra spaces)