### PR TITLE
Adopt Bun's native concurrent and serial test APIs

### DIFF
--- a/apps/cli/tests/commands/agents.test.ts
+++ b/apps/cli/tests/commands/agents.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   buildActivateCommand,
   buildAgentsCommand,
@@ -7,15 +7,15 @@ import {
   buildRouteCommand,
 } from "../../src/commands/agents-command.js";
 
-describe("agents command", () => {
-  describe("command structure", () => {
-    it("should build agents command successfully", () => {
+describe.concurrent("agents command", () => {
+  describe.concurrent("command structure", () => {
+    test.concurrent("should build agents command successfully", () => {
       const command = buildAgentsCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build individual subcommands successfully", () => {
+    test.concurrent("should build individual subcommands successfully", () => {
       expect(buildListCommand()).toBeDefined();
       expect(buildActivateCommand()).toBeDefined();
       expect(buildDeactivateCommand()).toBeDefined();

--- a/apps/cli/tests/commands/composer.test.ts
+++ b/apps/cli/tests/commands/composer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   buildRootCommand,
   buildRunner,
@@ -6,21 +6,21 @@ import {
 import { buildGHPRCommand } from "../../src/commands/gh-pr-command.js";
 import { buildSessionsCommand } from "../../src/commands/sessions-command.js";
 
-describe("composer command", () => {
-  describe("Root Command Structure", () => {
-    it("should build root command successfully", () => {
+describe.concurrent("composer command", () => {
+  describe.concurrent("Root Command Structure", () => {
+    test.concurrent("should build root command successfully", () => {
       const command = buildRootCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build runner successfully", () => {
+    test.concurrent("should build runner successfully", () => {
       const runner = buildRunner();
       expect(typeof runner).toBe("function");
       expect(runner).toBeDefined();
     });
 
-    it("should include all expected subcommands", () => {
+    test.concurrent("should include all expected subcommands", () => {
       const command = buildRootCommand();
       // Note: We can't directly inspect the internal command structure,
       // but we can verify the command builds without errors
@@ -28,48 +28,48 @@ describe("composer command", () => {
     });
   });
 
-  describe("PR Create Command Integration", () => {
-    it("should build pr-create command successfully", () => {
+  describe.concurrent("PR Create Command Integration", () => {
+    test.concurrent("should build pr-create command successfully", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should have pr-create subcommands", () => {
+    test.concurrent("should have pr-create subcommands", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Verify command structure is valid
     });
 
-    it("should handle pr-create command arguments correctly", () => {
+    test.concurrent("should handle pr-create command arguments correctly", () => {
       // Test that the command accepts proper arguments
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
   });
 
-  describe("Sessions Command Integration", () => {
-    it("should build sessions command successfully", () => {
+  describe.concurrent("Sessions Command Integration", () => {
+    test.concurrent("should build sessions command successfully", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should have sessions subcommands", () => {
+    test.concurrent("should have sessions subcommands", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Verify command structure is valid
     });
 
-    it("should handle sessions command arguments correctly", () => {
+    test.concurrent("should handle sessions command arguments correctly", () => {
       // Test that the command accepts proper arguments
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
     });
   });
 
-  describe("End-to-End Command Integration", () => {
-    it("should integrate pr-create command into root command", () => {
+  describe.concurrent("End-to-End Command Integration", () => {
+    test.concurrent("should integrate pr-create command into root command", () => {
       const rootCommand = buildRootCommand();
       const prCreateCommand = buildGHPRCommand();
       expect(rootCommand).toBeDefined();
@@ -77,7 +77,7 @@ describe("composer command", () => {
       // Both commands should be buildable without conflicts
     });
 
-    it("should integrate sessions command into root command", () => {
+    test.concurrent("should integrate sessions command into root command", () => {
       const rootCommand = buildRootCommand();
       const sessionsCommand = buildSessionsCommand();
       expect(rootCommand).toBeDefined();
@@ -85,7 +85,7 @@ describe("composer command", () => {
       // Both commands should be buildable without conflicts
     });
 
-    it("should handle multiple new commands without conflicts", () => {
+    test.concurrent("should handle multiple new commands without conflicts", () => {
       const rootCommand = buildRootCommand();
       const prCreateCommand = buildGHPRCommand();
       const sessionsCommand = buildSessionsCommand();
@@ -99,8 +99,8 @@ describe("composer command", () => {
     });
   });
 
-  describe("Command Validation", () => {
-    it("should validate command structure integrity", () => {
+  describe.concurrent("Command Validation", () => {
+    test.concurrent("should validate command structure integrity", () => {
       const rootCommand = buildRootCommand();
       expect(rootCommand).toBeDefined();
 
@@ -108,7 +108,7 @@ describe("composer command", () => {
       expect(typeof rootCommand).toBe("object");
     });
 
-    it("should handle command composition correctly", () => {
+    test.concurrent("should handle command composition correctly", () => {
       // Test that commands can be composed together
       const rootCommand = buildRootCommand();
       expect(rootCommand).toBeDefined();

--- a/apps/cli/tests/commands/config.test.ts
+++ b/apps/cli/tests/commands/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -13,6 +13,7 @@ import {
 // Mock config directory for testing
 const mockConfigDir = join(homedir(), ".config", "open-composer-test");
 const _mockConfigPath = join(mockConfigDir, "config.json");
+
 
 describe("config command", () => {
   beforeEach(async () => {
@@ -30,13 +31,13 @@ describe("config command", () => {
   });
 
   describe("command structure", () => {
-    it("should build config command successfully", () => {
+    test.serial("should build config command successfully", () => {
       const command = buildConfigCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build individual subcommands successfully", () => {
+    test.serial("should build individual subcommands successfully", () => {
       expect(buildGetCommand()).toBeDefined();
       expect(buildSetCommand()).toBeDefined();
       expect(buildShowCommand()).toBeDefined();
@@ -46,28 +47,28 @@ describe("config command", () => {
 
   describe("config operations", () => {
     describe("get command", () => {
-      it("should build get command with optional key parameter", () => {
+      test.serial("should build get command with optional key parameter", () => {
         const command = buildGetCommand();
         expect(command).toBeDefined();
       });
     });
 
     describe("set command", () => {
-      it("should build set command with required key and value parameters", () => {
+      test.serial("should build set command with required key and value parameters", () => {
         const command = buildSetCommand();
         expect(command).toBeDefined();
       });
     });
 
     describe("show command", () => {
-      it("should build show command successfully", () => {
+      test.serial("should build show command successfully", () => {
         const command = buildShowCommand();
         expect(command).toBeDefined();
       });
     });
 
     describe("clear command", () => {
-      it("should build clear command successfully", () => {
+      test.serial("should build clear command successfully", () => {
         const command = buildClearCommand();
         expect(command).toBeDefined();
       });

--- a/apps/cli/tests/commands/git-worktree.test.ts
+++ b/apps/cli/tests/commands/git-worktree.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { buildGitWorktreeCommand } from "../../src/commands/git-worktree-command.js";
 
-describe("git-worktree command", () => {
-  it("should build git-worktree command successfully", () => {
+
+describe.concurrent("git-worktree command", () => {
+  test.concurrent("should build git-worktree command successfully", () => {
     const command = buildGitWorktreeCommand();
     expect(command).toBeDefined();
     expect(typeof command).toBe("object");

--- a/apps/cli/tests/commands/pr-create.test.ts
+++ b/apps/cli/tests/commands/pr-create.test.ts
@@ -1,169 +1,170 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { buildGHPRCommand } from "../../src/commands/gh-pr-command.js";
 
-describe("pr-create command", () => {
-  describe("Command Structure", () => {
-    it("should build pr-create command successfully", () => {
+
+describe.concurrent("pr-create command", () => {
+  describe.concurrent("Command Structure", () => {
+    test.concurrent("should build pr-create command successfully", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should have proper command name", () => {
+    test.concurrent("should have proper command name", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Command should be named 'pr-create'
     });
 
-    it("should have create and auto subcommands", () => {
+    test.concurrent("should have create and auto subcommands", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should contain both 'create' and 'auto' subcommands
     });
   });
 
-  describe("Create Subcommand", () => {
-    it("should handle create subcommand with required arguments", () => {
+  describe.concurrent("Create Subcommand", () => {
+    test.concurrent("should handle create subcommand with required arguments", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept title argument
     });
 
-    it("should handle optional body argument", () => {
+    test.concurrent("should handle optional body argument", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept optional body argument
     });
 
-    it("should handle optional base branch argument", () => {
+    test.concurrent("should handle optional base branch argument", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept optional base argument
     });
 
-    it("should handle optional head branch argument", () => {
+    test.concurrent("should handle optional head branch argument", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept optional head argument
     });
 
-    it("should handle draft option", () => {
+    test.concurrent("should handle draft option", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept draft boolean option
     });
 
-    it("should handle skip-checks option", () => {
+    test.concurrent("should handle skip-checks option", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept skip-checks boolean option
     });
 
-    it("should handle skip-changeset option", () => {
+    test.concurrent("should handle skip-changeset option", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept skip-changeset boolean option
     });
   });
 
-  describe("Auto Subcommand", () => {
-    it("should handle auto subcommand with required arguments", () => {
+  describe.concurrent("Auto Subcommand", () => {
+    test.concurrent("should handle auto subcommand with required arguments", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should accept title argument
     });
 
-    it("should handle auto subcommand optional arguments", () => {
+    test.concurrent("should handle auto subcommand optional arguments", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should handle optional arguments like create subcommand
     });
 
-    it("should enable auto-merge by default for auto subcommand", () => {
+    test.concurrent("should enable auto-merge by default for auto subcommand", () => {
       // The auto subcommand should set draft: false and auto: true
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
   });
 
-  describe("Integration Tests", () => {
-    it("should integrate with PRCreateCli service", () => {
+  describe.concurrent("Integration Tests", () => {
+    test.concurrent("should integrate with PRCreateCli service", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should properly instantiate and use PRCreateCli
     });
 
-    it("should handle telemetry tracking", () => {
+    test.concurrent("should handle telemetry tracking", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should track command usage and feature usage
     });
 
-    it("should validate git state before PR creation", () => {
+    test.concurrent("should validate git state before PR creation", () => {
       // Should check for uncommitted changes, main branch, etc.
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
 
-    it("should perform quality assurance checks", () => {
+    test.concurrent("should perform quality assurance checks", () => {
       // Should run tests, linting, etc. unless skipped
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
 
-    it("should generate changesets when configured", () => {
+    test.concurrent("should generate changesets when configured", () => {
       // Should generate changeset unless skip-changeset is used
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
 
-    it("should create PR with proper formatting", () => {
+    test.concurrent("should create PR with proper formatting", () => {
       // Should create PR with title, body, base, head
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
     });
   });
 
-  describe("Error Handling", () => {
-    it("should handle GitHub CLI not installed", () => {
+  describe.concurrent("Error Handling", () => {
+    test.concurrent("should handle GitHub CLI not installed", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should exit with error if gh CLI not available
     });
 
-    it("should handle GitHub CLI not authenticated", () => {
+    test.concurrent("should handle GitHub CLI not authenticated", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should exit with error if not authenticated
     });
 
-    it("should handle being on main branch", () => {
+    test.concurrent("should handle being on main branch", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should exit with error if on main/master branch
     });
 
-    it("should handle uncommitted changes", () => {
+    test.concurrent("should handle uncommitted changes", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should exit with error if uncommitted changes exist
     });
 
-    it("should handle no commits to create PR from", () => {
+    test.concurrent("should handle no commits to create PR from", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Should exit with error if no commits exist
     });
   });
 
-  describe("Mock Integration Tests", () => {
-    it("should handle mock auto-merge PR creation", () => {
+  describe.concurrent("Mock Integration Tests", () => {
+    test.concurrent("should handle mock auto-merge PR creation", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Test command builds correctly for auto-merge scenarios
     });
 
-    it("should handle mock PR creation workflow", () => {
+    test.concurrent("should handle mock PR creation workflow", () => {
       const command = buildGHPRCommand();
       expect(command).toBeDefined();
       // Test command structure supports PR creation workflow

--- a/apps/cli/tests/commands/sessions.test.ts
+++ b/apps/cli/tests/commands/sessions.test.ts
@@ -1,195 +1,196 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { buildSessionsCommand } from "../../src/commands/sessions-command.js";
 
-describe("sessions command", () => {
-  describe("Command Structure", () => {
-    it("should build sessions command successfully", () => {
+
+describe.concurrent("sessions command", () => {
+  describe.concurrent("Command Structure", () => {
+    test.concurrent("should build sessions command successfully", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should have proper command name", () => {
+    test.concurrent("should have proper command name", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Command should be named 'sessions'
     });
 
-    it("should have all expected subcommands", () => {
+    test.concurrent("should have all expected subcommands", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should contain create, list, switch, archive, delete subcommands
     });
   });
 
-  describe("Create Subcommand", () => {
-    it("should handle create subcommand with optional name argument", () => {
+  describe.concurrent("Create Subcommand", () => {
+    test.concurrent("should handle create subcommand with optional name argument", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should accept optional name argument
     });
 
-    it("should handle create subcommand without name argument", () => {
+    test.concurrent("should handle create subcommand without name argument", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should work without name (will prompt)
     });
 
-    it("should track telemetry for create command", () => {
+    test.concurrent("should track telemetry for create command", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command usage
     });
   });
 
-  describe("List Subcommand", () => {
-    it("should handle list subcommand", () => {
+  describe.concurrent("List Subcommand", () => {
+    test.concurrent("should handle list subcommand", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should list all sessions
     });
 
-    it("should track telemetry for list command", () => {
+    test.concurrent("should track telemetry for list command", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command usage
     });
   });
 
-  describe("Switch Subcommand", () => {
-    it("should handle switch subcommand with required session-id argument", () => {
+  describe.concurrent("Switch Subcommand", () => {
+    test.concurrent("should handle switch subcommand with required session-id argument", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should accept integer session-id argument
     });
 
-    it("should validate session-id is an integer", () => {
+    test.concurrent("should validate session-id is an integer", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should validate session-id type
     });
 
-    it("should track telemetry for switch command", () => {
+    test.concurrent("should track telemetry for switch command", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command usage
     });
   });
 
-  describe("Archive Subcommand", () => {
-    it("should handle archive subcommand with required session-id argument", () => {
+  describe.concurrent("Archive Subcommand", () => {
+    test.concurrent("should handle archive subcommand with required session-id argument", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should accept integer session-id argument
     });
 
-    it("should validate session-id for archive", () => {
+    test.concurrent("should validate session-id for archive", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should validate session-id type
     });
 
-    it("should track telemetry for archive command", () => {
+    test.concurrent("should track telemetry for archive command", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command usage
     });
   });
 
-  describe("Delete Subcommand", () => {
-    it("should handle delete subcommand with required session-id argument", () => {
+  describe.concurrent("Delete Subcommand", () => {
+    test.concurrent("should handle delete subcommand with required session-id argument", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should accept integer session-id argument
     });
 
-    it("should validate session-id for delete", () => {
+    test.concurrent("should validate session-id for delete", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should validate session-id type
     });
 
-    it("should track telemetry for delete command", () => {
+    test.concurrent("should track telemetry for delete command", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command usage
     });
   });
 
-  describe("Integration Tests", () => {
-    it("should integrate with SessionsCli service", () => {
+  describe.concurrent("Integration Tests", () => {
+    test.concurrent("should integrate with SessionsCli service", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should properly instantiate and use SessionsCli
     });
 
-    it("should handle telemetry tracking for all subcommands", () => {
+    test.concurrent("should handle telemetry tracking for all subcommands", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should track command and feature usage for all operations
     });
 
-    it("should handle session operations correctly", () => {
+    test.concurrent("should handle session operations correctly", () => {
       // Should delegate to appropriate SessionsCli methods
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
     });
   });
 
-  describe("Error Handling", () => {
-    it("should handle invalid session-id arguments", () => {
+  describe.concurrent("Error Handling", () => {
+    test.concurrent("should handle invalid session-id arguments", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should validate session-id is positive integer
     });
 
-    it("should handle non-existent sessions", () => {
+    test.concurrent("should handle non-existent sessions", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should handle attempts to operate on non-existent sessions
     });
 
-    it("should handle database errors gracefully", () => {
+    test.concurrent("should handle database errors gracefully", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Should handle database connection or query errors
     });
   });
 
-  describe("Mock Integration Tests", () => {
-    it("should handle mock session operations", () => {
+  describe.concurrent("Mock Integration Tests", () => {
+    test.concurrent("should handle mock session operations", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Test command structure supports session operations
     });
 
-    it("should handle mock session listing scenarios", () => {
+    test.concurrent("should handle mock session listing scenarios", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Test command structure supports session listing
     });
 
-    it("should handle mock session lifecycle operations", () => {
+    test.concurrent("should handle mock session lifecycle operations", () => {
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
       // Test command supports create, switch, archive, delete operations
     });
   });
 
-  describe("End-to-End Scenarios", () => {
-    it("should support complete session lifecycle", () => {
+  describe.concurrent("End-to-End Scenarios", () => {
+    test.concurrent("should support complete session lifecycle", () => {
       // Test creating, listing, switching, archiving, deleting sessions
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
     });
 
-    it("should handle concurrent session operations", () => {
+    test.concurrent("should handle concurrent session operations", () => {
       // Test that multiple session operations can be performed
       const command = buildSessionsCommand();
       expect(command).toBeDefined();
     });
 
-    it("should maintain session state consistency", () => {
+    test.concurrent("should maintain session state consistency", () => {
       // Test that session operations maintain consistent state
       const command = buildSessionsCommand();
       expect(command).toBeDefined();

--- a/apps/cli/tests/commands/settings.test.ts
+++ b/apps/cli/tests/commands/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   buildDeleteCommand,
   buildGetCommand,
@@ -7,35 +7,36 @@ import {
   buildSettingsCommand,
 } from "../../src/commands/settings-command.js";
 
-describe("settings command", () => {
-  describe("buildSettingsCommand", () => {
-    it("should build settings command successfully", () => {
+
+describe.concurrent("settings command", () => {
+  describe.concurrent("buildSettingsCommand", () => {
+    test.concurrent("should build settings command successfully", () => {
       const command = buildSettingsCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
   });
 
-  describe("subcommands", () => {
-    it("should build get command successfully", () => {
+  describe.concurrent("subcommands", () => {
+    test.concurrent("should build get command successfully", () => {
       const command = buildGetCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build set command successfully", () => {
+    test.concurrent("should build set command successfully", () => {
       const command = buildSetCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build list command successfully", () => {
+    test.concurrent("should build list command successfully", () => {
       const command = buildListCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");
     });
 
-    it("should build delete command successfully", () => {
+    test.concurrent("should build delete command successfully", () => {
       const command = buildDeleteCommand();
       expect(command).toBeDefined();
       expect(typeof command).toBe("object");

--- a/apps/cli/tests/commands/stack.test.ts
+++ b/apps/cli/tests/commands/stack.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { buildStackCommand } from "../../src/commands/stack-command.js";
 
-describe("stack command", () => {
-  it("should build stack command successfully", () => {
+
+describe.concurrent("stack command", () => {
+  test.concurrent("should build stack command successfully", () => {
     const command = buildStackCommand();
     expect(command).toBeDefined();
     expect(typeof command).toBe("object");

--- a/apps/cli/tests/services/agent-service.test.ts
+++ b/apps/cli/tests/services/agent-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, test, mock, spyOn } from "bun:test";
 import {
   ConfigService,
   type ConfigServiceInterface,
@@ -87,9 +87,10 @@ const MockCacheLive = Layer.succeed(CacheService, mockCacheService);
 // Mock console.log to capture output
 const mockConsoleLog = spyOn(console, "log");
 
+
 describe("AgentService", () => {
   describe("list", () => {
-    it("should list all agents when activeOnly is false", async () => {
+    test.serial("should list all agents when activeOnly is false", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -112,7 +113,7 @@ describe("AgentService", () => {
       expect(calls).toContain("* test            Test agent");
     });
 
-    it("should list only active agents when activeOnly is true", async () => {
+    test.serial("should list only active agents when activeOnly is true", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -139,7 +140,7 @@ describe("AgentService", () => {
   });
 
   describe("activate", () => {
-    it("should activate an agent", async () => {
+    test.serial("should activate an agent", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -157,7 +158,7 @@ describe("AgentService", () => {
       expect(calls).toContain("Activated agent: claude-code");
     });
 
-    it("should handle agent not found", async () => {
+    test.serial("should handle agent not found", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -177,7 +178,7 @@ describe("AgentService", () => {
   });
 
   describe("deactivate", () => {
-    it("should deactivate an agent", async () => {
+    test.serial("should deactivate an agent", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -195,7 +196,7 @@ describe("AgentService", () => {
       expect(calls).toContain("Deactivated agent: claude-code");
     });
 
-    it("should handle agent not found", async () => {
+    test.serial("should handle agent not found", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 
@@ -215,7 +216,7 @@ describe("AgentService", () => {
   });
 
   describe("route", () => {
-    it("should route a query", async () => {
+    test.serial("should route a query", async () => {
       mockConsoleLog.mockClear();
       const service = new AgentService(["open-composer"]);
 

--- a/apps/cli/tests/services/cache-service.test.ts
+++ b/apps/cli/tests/services/cache-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,7 @@ import type { AgentCache } from "../../src/services/cache-service";
 // Mock file system operations for testing
 const mockCacheDir = join(homedir(), ".config", "open-composer-test");
 const mockCachePath = join(mockCacheDir, "cache.json");
+
 
 // Helper functions to test cache operations directly
 async function testGetAgentCache(): Promise<AgentCache | undefined> {
@@ -54,12 +55,12 @@ describe("CacheService", () => {
   });
 
   describe("getAgentCache", () => {
-    it("should return undefined when no cache file exists", async () => {
+    test.serial("should return undefined when no cache file exists", async () => {
       const result = await testGetAgentCache();
       expect(result).toBeUndefined();
     });
 
-    it("should return cache data when file exists", async () => {
+    test.serial("should return cache data when file exists", async () => {
       const testCache: AgentCache = {
         agents: [
           {
@@ -79,7 +80,7 @@ describe("CacheService", () => {
   });
 
   describe("updateAgentCache", () => {
-    it("should store agent cache data", async () => {
+    test.serial("should store agent cache data", async () => {
       const testCache: AgentCache = {
         agents: [
           {
@@ -104,7 +105,7 @@ describe("CacheService", () => {
   });
 
   describe("clearAgentCache", () => {
-    it("should clear the cache to empty state", async () => {
+    test.serial("should clear the cache to empty state", async () => {
       const testCache: AgentCache = {
         agents: [
           {

--- a/apps/cli/tests/services/config-service.test.ts
+++ b/apps/cli/tests/services/config-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,7 @@ import type { UserConfig } from "@open-composer/config";
 // Mock file system operations for testing
 const mockConfigDir = join(homedir(), ".config", "open-composer-test");
 const mockConfigPath = join(mockConfigDir, "config.json");
+
 
 // Helper functions to test config operations directly
 async function testGetConfig(): Promise<UserConfig> {
@@ -116,7 +117,7 @@ describe("Config Operations", () => {
   });
 
   describe("getConfig", () => {
-    it("should return default config when no file exists", async () => {
+    test.serial("should return default config when no file exists", async () => {
       const result = await testGetConfig();
 
       expect(result).toEqual({
@@ -126,7 +127,7 @@ describe("Config Operations", () => {
       });
     });
 
-    it("should read existing config file", async () => {
+    test.serial("should read existing config file", async () => {
       const testConfig = {
         version: "1.0.0",
         createdAt: "2024-01-01T00:00:00.000Z",
@@ -157,7 +158,7 @@ describe("Config Operations", () => {
       });
     });
 
-    it("should handle invalid JSON gracefully", async () => {
+    test.serial("should handle invalid JSON gracefully", async () => {
       await writeFile(mockConfigPath, "invalid json", "utf8");
 
       const result = await testGetConfig();
@@ -171,7 +172,7 @@ describe("Config Operations", () => {
   });
 
   describe("setTelemetryConsent", () => {
-    it("should enable telemetry consent", async () => {
+    test.serial("should enable telemetry consent", async () => {
       const result = await testSetTelemetryConsent(true);
 
       expect(result.telemetry?.enabled).toBe(true);
@@ -179,7 +180,7 @@ describe("Config Operations", () => {
       expect(result.telemetry?.version).toBe("1.0.0");
     });
 
-    it("should disable telemetry consent", async () => {
+    test.serial("should disable telemetry consent", async () => {
       const result = await testSetTelemetryConsent(false);
 
       expect(result.telemetry?.enabled).toBe(false);
@@ -187,7 +188,7 @@ describe("Config Operations", () => {
       expect(result.telemetry?.version).toBe("1.0.0");
     });
 
-    it("should persist consent to file", async () => {
+    test.serial("should persist consent to file", async () => {
       await testSetTelemetryConsent(true);
 
       // Verify file was written
@@ -200,7 +201,7 @@ describe("Config Operations", () => {
   });
 
   describe("updateConfig", () => {
-    it("should update config with partial data", async () => {
+    test.serial("should update config with partial data", async () => {
       const result = await testUpdateConfig({
         version: "2.0.0",
         telemetry: {
@@ -217,13 +218,13 @@ describe("Config Operations", () => {
   });
 
   describe("getTelemetryConsent", () => {
-    it("should return false when telemetry is not configured", async () => {
+    test.serial("should return false when telemetry is not configured", async () => {
       const result = await testGetTelemetryConsent();
 
       expect(result).toBe(false);
     });
 
-    it("should return true when telemetry is enabled", async () => {
+    test.serial("should return true when telemetry is enabled", async () => {
       // First set telemetry consent
       await testSetTelemetryConsent(true);
 
@@ -233,7 +234,7 @@ describe("Config Operations", () => {
       expect(result).toBe(true);
     });
 
-    it("should return false when telemetry is disabled", async () => {
+    test.serial("should return false when telemetry is disabled", async () => {
       // First set telemetry consent to false
       await testSetTelemetryConsent(false);
 

--- a/apps/cli/tests/services/gh-pr-service.test.ts
+++ b/apps/cli/tests/services/gh-pr-service.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, mock, spyOn } from "bun:test";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import * as Effect from "effect/Effect";
@@ -133,6 +125,7 @@ const mockRequire = mock((path: string) => {
 // @ts-expect-error - mocking global require
 spyOn(global, "require").mockImplementation(mockRequire);
 
+
 describe("GhPRService", () => {
   let service: GhPRService;
 
@@ -203,7 +196,7 @@ describe("GhPRService", () => {
   });
 
   describe("checkGitHubCliSetup", () => {
-    it("should return success when CLI is available and authenticated", async () => {
+    test.serial("should return success when CLI is available and authenticated", async () => {
       const result = await Effect.runPromise(service.checkGitHubCliSetup());
 
       expect(result.cliAvailable).toBe(true);
@@ -211,7 +204,7 @@ describe("GhPRService", () => {
       expect(result.repository).toBe("test/repo");
     });
 
-    it("should return CLI not available when which fails", async () => {
+    test.serial("should return CLI not available when which fails", async () => {
       mockExecFileAsync.mockImplementationOnce(
         async (cmd: string, args: string[]) => {
           if (cmd === "which" && args[0] === "gh") {
@@ -229,7 +222,7 @@ describe("GhPRService", () => {
       expect(result.repository).toBeUndefined();
     });
 
-    it("should return not authenticated when auth status fails", async () => {
+    test.serial("should return not authenticated when auth status fails", async () => {
       // First call (which gh) should succeed
       mockExecFileAsync.mockImplementationOnce(
         async (cmd: string, args: string[]) => {
@@ -258,7 +251,7 @@ describe("GhPRService", () => {
   });
 
   describe("validateGitState", () => {
-    it("should validate git state successfully", async () => {
+    test.serial("should validate git state successfully", async () => {
       const result = await Effect.runPromise(service.validateGitState());
 
       expect(result.currentBranch).toBe("main");
@@ -267,7 +260,7 @@ describe("GhPRService", () => {
       expect(result.isOnMainBranch).toBe(true);
     });
 
-    it("should handle uncommitted changes", async () => {
+    test.serial("should handle uncommitted changes", async () => {
       // First call (git rev-parse) should succeed
       mockExecFileAsync.mockImplementationOnce(
         async (cmd: string, args: string[]) => {
@@ -300,7 +293,7 @@ describe("GhPRService", () => {
       expect(result.hasUncommittedChanges).toBe(true);
     });
 
-    it("should handle commits ahead of origin", async () => {
+    test.serial("should handle commits ahead of origin", async () => {
       // First call (git rev-parse) should succeed
       mockExecFileAsync.mockImplementationOnce(
         async (cmd: string, args: string[]) => {
@@ -344,7 +337,7 @@ describe("GhPRService", () => {
   });
 
   describe("detectPackageManager", () => {
-    it("should detect bun when bun.lockb exists", async () => {
+    test.serial("should detect bun when bun.lockb exists", async () => {
       (existsSync as unknown as ReturnType<typeof mock>).mockImplementation(
         (path: string) => path.includes("bun.lockb"),
       );
@@ -354,7 +347,7 @@ describe("GhPRService", () => {
       expect(result).toBe("bun");
     });
 
-    it("should detect pnpm when pnpm-lock.yaml exists", async () => {
+    test.serial("should detect pnpm when pnpm-lock.yaml exists", async () => {
       (existsSync as unknown as ReturnType<typeof mock>).mockImplementation(
         (path: string) => path.includes("pnpm-lock.yaml"),
       );
@@ -364,7 +357,7 @@ describe("GhPRService", () => {
       expect(result).toBe("pnpm");
     });
 
-    it("should detect yarn when yarn.lock exists", async () => {
+    test.serial("should detect yarn when yarn.lock exists", async () => {
       (existsSync as unknown as ReturnType<typeof mock>).mockImplementation(
         (path: string) => path.includes("yarn.lock"),
       );
@@ -374,7 +367,7 @@ describe("GhPRService", () => {
       expect(result).toBe("yarn");
     });
 
-    it("should detect npm when package-lock.json exists", async () => {
+    test.serial("should detect npm when package-lock.json exists", async () => {
       (existsSync as unknown as ReturnType<typeof mock>).mockImplementation(
         (path: string) => path.includes("package-lock.json"),
       );
@@ -384,7 +377,7 @@ describe("GhPRService", () => {
       expect(result).toBe("npm");
     });
 
-    it("should default to npm", async () => {
+    test.serial("should default to npm", async () => {
       (existsSync as unknown as ReturnType<typeof mock>).mockReturnValue(false);
 
       const result = await Effect.runPromise(service.detectPackageManager());
@@ -394,7 +387,7 @@ describe("GhPRService", () => {
   });
 
   describe("runQualityChecks", () => {
-    it("should run all quality checks successfully", async () => {
+    test.serial("should run all quality checks successfully", async () => {
       const result = await Effect.runPromise(service.runQualityChecks("bun"));
 
       expect(result.lintPassed).toBe(true);
@@ -403,7 +396,7 @@ describe("GhPRService", () => {
       expect(result.errors).toEqual([]);
     });
 
-    it("should handle linting failure", async () => {
+    test.serial("should handle linting failure", async () => {
       mockExecFileAsync.mockImplementationOnce(
         async (cmd: string, args: string[]) => {
           if (cmd === "bun" && args.includes("lint")) {
@@ -422,7 +415,7 @@ describe("GhPRService", () => {
       expect(result.errors).toContain("Linting failed: Error: Linting failed");
     });
 
-    it("should handle test failure", async () => {
+    test.serial("should handle test failure", async () => {
       mockExecFileAsync.mockImplementation(
         async (cmd: string, args: string[]) => {
           if (cmd === "bun" && args.includes("lint")) {
@@ -451,7 +444,7 @@ describe("GhPRService", () => {
   });
 
   describe("createPullRequest", () => {
-    it("should create a pull request", async () => {
+    test.serial("should create a pull request", async () => {
       const options = {
         title: "Test PR",
         body: "Test body",
@@ -470,7 +463,7 @@ describe("GhPRService", () => {
   });
 
   describe("getPRStatus", () => {
-    it("should get PR status", async () => {
+    test.serial("should get PR status", async () => {
       const result = await Effect.runPromise(service.getPRStatus(123));
 
       expect(result.isInMergeQueue).toBe(false);
@@ -481,7 +474,7 @@ describe("GhPRService", () => {
   });
 
   describe("listPRs", () => {
-    it("should list pull requests", async () => {
+    test.serial("should list pull requests", async () => {
       const result = await Effect.runPromise(service.listPRs());
 
       expect(result).toContain("123");
@@ -490,7 +483,7 @@ describe("GhPRService", () => {
       expect(result).toContain("Another PR");
     });
 
-    it("should list PRs with options", async () => {
+    test.serial("should list PRs with options", async () => {
       const options = { state: "open" as const, author: "testuser" };
 
       const result = await Effect.runPromise(service.listPRs(options));
@@ -501,7 +494,7 @@ describe("GhPRService", () => {
   });
 
   describe("viewPR", () => {
-    it("should view PR details", async () => {
+    test.serial("should view PR details", async () => {
       const result = await Effect.runPromise(service.viewPR(123));
 
       expect(result).toContain("PR #123");
@@ -509,7 +502,7 @@ describe("GhPRService", () => {
       expect(result).toContain("State: open");
     });
 
-    it("should view PR with options", async () => {
+    test.serial("should view PR with options", async () => {
       const options = { json: "true" };
 
       const result = await Effect.runPromise(service.viewPR("123", options));
@@ -519,13 +512,13 @@ describe("GhPRService", () => {
   });
 
   describe("mergePR", () => {
-    it("should merge a pull request", async () => {
+    test.serial("should merge a pull request", async () => {
       const result = await Effect.runPromise(service.mergePR(123));
 
       expect(result).toContain("Successfully merged PR #123");
     });
 
-    it("should merge PR with options", async () => {
+    test.serial("should merge PR with options", async () => {
       const options = { method: "squash" as const, deleteBranch: true };
 
       const result = await Effect.runPromise(service.mergePR(123, options));

--- a/apps/cli/tests/services/git-worktree-service.test.ts
+++ b/apps/cli/tests/services/git-worktree-service.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, mock, spyOn } from "bun:test";
 import type {
   AddOptions,
   ListOptions,
@@ -83,6 +75,7 @@ mock.module("@open-composer/git-worktrees", () => ({
 // Mock Effect and console
 const mockConsoleLog = spyOn(console, "log");
 
+
 // Import GitWorktreeService after mocks are set up
 import {
   type CreateGitWorktreeOptions,
@@ -109,7 +102,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("list", () => {
-    it("should list git worktrees", async () => {
+    test.serial("should list git worktrees", async () => {
       const result = await Effect.runPromise(
         service.list().pipe(Effect.provide(GitLive)),
       );
@@ -117,7 +110,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should handle empty worktree list", async () => {
+    test.serial("should handle empty worktree list", async () => {
       // Temporarily override the mock to return empty list
       const originalMock = service.listWorktrees;
       service.listWorktrees = () => Effect.succeed([]);
@@ -134,7 +127,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("create", () => {
-    it("should create a worktree with branch", async () => {
+    test.serial("should create a worktree with branch", async () => {
       const options: CreateGitWorktreeOptions = {
         path: "/tmp/new-worktree",
         branch: "new-feature",
@@ -151,7 +144,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should create a worktree with ref", async () => {
+    test.serial("should create a worktree with ref", async () => {
       const options: CreateGitWorktreeOptions = {
         path: "/tmp/new-worktree",
         ref: "v1.0.0",
@@ -168,7 +161,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should create a detached worktree", async () => {
+    test.serial("should create a detached worktree", async () => {
       const options: CreateGitWorktreeOptions = {
         path: "/tmp/new-worktree",
         force: false,
@@ -186,7 +179,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("edit", () => {
-    it("should move a worktree", async () => {
+    test.serial("should move a worktree", async () => {
       const options: EditGitWorktreeOptions = {
         from: "/old/path",
         to: "/new/path",
@@ -202,7 +195,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("prune", () => {
-    it("should prune worktrees in dry-run mode", async () => {
+    test.serial("should prune worktrees in dry-run mode", async () => {
       const options: PruneGitWorktreeOptions = {
         dryRun: true,
         verbose: false,
@@ -216,7 +209,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should show message when no prunable worktrees in dry-run", async () => {
+    test.serial("should show message when no prunable worktrees in dry-run", async () => {
       // Temporarily override to return worktrees with no prunable ones
       const originalMock = service.listWorktrees;
       service.listWorktrees = () =>
@@ -245,7 +238,7 @@ describe("GitWorktreeService", () => {
       service.listWorktrees = originalMock;
     });
 
-    it("should actually prune worktrees", async () => {
+    test.serial("should actually prune worktrees", async () => {
       const options: PruneGitWorktreeOptions = {
         dryRun: false,
         verbose: true,
@@ -259,7 +252,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should handle no worktrees pruned", async () => {
+    test.serial("should handle no worktrees pruned", async () => {
       // Same worktrees before and after (none removed)
       const options: PruneGitWorktreeOptions = {
         dryRun: false,
@@ -274,7 +267,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("switch", () => {
-    it("should switch to a worktree", async () => {
+    test.serial("should switch to a worktree", async () => {
       const result = await Effect.runPromise(
         service
           .switch("/path/to/feature-worktree")
@@ -284,7 +277,7 @@ describe("GitWorktreeService", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should switch to detached worktree", async () => {
+    test.serial("should switch to detached worktree", async () => {
       // Temporarily override to return detached worktree
       const originalMock = service.listWorktrees;
       service.listWorktrees = () =>
@@ -311,7 +304,7 @@ describe("GitWorktreeService", () => {
       service.listWorktrees = originalMock;
     });
 
-    it("should fail when worktree not found", async () => {
+    test.serial("should fail when worktree not found", async () => {
       const result = await Effect.runPromiseExit(
         service.switch("/nonexistent/path").pipe(Effect.provide(GitLive)),
       );
@@ -332,7 +325,7 @@ describe("GitWorktreeService", () => {
   });
 
   describe("static make", () => {
-    it("should create a service instance", () => {
+    test.serial("should create a service instance", () => {
       const result = Effect.runSync(
         GitWorktreeService.make().pipe(Effect.provide(GitLive)),
       );

--- a/apps/cli/tests/services/sessions-service.test.ts
+++ b/apps/cli/tests/services/sessions-service.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, mock, spyOn } from "bun:test";
 import * as Effect from "effect/Effect";
 import { SessionsService } from "../../src/services/sessions-service.js";
 
@@ -56,6 +48,7 @@ mock.module("../../src/services/stack-service", () => ({
 // Mock console.log
 const mockConsoleLog = spyOn(console, "log");
 
+
 describe("SessionsService", () => {
   let service: SessionsService;
 
@@ -75,7 +68,7 @@ describe("SessionsService", () => {
   // The database mocking is complex and requires deep understanding of Drizzle ORM internals
   // For now, we provide a basic test structure that can be expanded later
 
-  it("should instantiate SessionsService", () => {
+  test.serial("should instantiate SessionsService", () => {
     expect(service).toBeInstanceOf(SessionsService);
   });
 
@@ -83,7 +76,7 @@ describe("SessionsService", () => {
   // These would require extensive mocking of the Drizzle ORM query builder
   /*
   describe("createInteractive", () => {
-    it("should create a session with existing workspace", async () => {
+    test.serial("should create a session with existing workspace", async () => {
       // Test implementation here
     });
   });

--- a/apps/cli/tests/services/settings-service.test.ts
+++ b/apps/cli/tests/services/settings-service.test.ts
@@ -1,15 +1,16 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   SettingsLive,
   SettingsService,
 } from "../../src/services/settings-service.js";
 
-describe("SettingsService", () => {
+
+describe.concurrent("SettingsService", () => {
   // TODO: Implement proper database mocking for comprehensive tests
   // The database mocking is complex and requires deep understanding of Drizzle ORM internals
   // For now, we provide a basic test structure that can be expanded later
 
-  it("should have SettingsService interface", () => {
+  test.concurrent("should have SettingsService interface", () => {
     // Basic smoke test to ensure the module can be imported
     expect(SettingsService).toBeDefined();
     expect(SettingsLive).toBeDefined();

--- a/apps/cli/tests/services/stack-service.test.ts
+++ b/apps/cli/tests/services/stack-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, test, mock, spyOn } from "bun:test";
 import * as Effect from "effect/Effect";
 
 // Mock the git-stack package functions
@@ -52,14 +52,15 @@ const _mockConsoleError = spyOn(console, "error");
 // Import StackService after mocks are set up
 import { StackService } from "../../src/services/stack-service.js";
 
-describe("StackService", () => {
-  describe("service instantiation", () => {
-    it("should handle default constructor", () => {
+
+describe.concurrent("StackService", () => {
+  describe.concurrent("service instantiation", () => {
+    test.concurrent("should handle default constructor", () => {
       const defaultService = new StackService();
       expect(defaultService).toBeInstanceOf(StackService);
     });
 
-    it("should create service with dependencies", () => {
+    test.concurrent("should create service with dependencies", () => {
       const service = new StackService(
         mockLogStack,
         mockStatusStack,

--- a/apps/cli/tests/services/telemetry-service.test.ts
+++ b/apps/cli/tests/services/telemetry-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { TelemetryConfig } from "@open-composer/config";
 
 // Mock PostHog client
@@ -13,9 +13,10 @@ const _mockPostHogClient = {
 // Note: In a real implementation, we would mock the PostHog constructor
 // For this test, we're testing the service interface directly
 
-describe("TelemetryService", () => {
-  describe("exception autocapture configuration", () => {
-    it("should create PostHog client with exception autocapture enabled", () => {
+
+describe.concurrent("TelemetryService", () => {
+  describe.concurrent("exception autocapture configuration", () => {
+    test.concurrent("should create PostHog client with exception autocapture enabled", () => {
       const testConfig: TelemetryConfig = {
         enabled: true,
         apiKey: "test-api-key",
@@ -29,7 +30,7 @@ describe("TelemetryService", () => {
       expect(testConfig.host).toBe("https://test.posthog.com");
     });
 
-    it("should use production API key and host by default", () => {
+    test.concurrent("should use production API key and host by default", () => {
       // Test that the default configuration uses production values from the PostHog docs
       const productionApiKey =
         "phc_myz44Az2Eim07Kk1aP3jWLVb2pzn75QWVDhOMv9dSsU";

--- a/packages/agent-router/tests/agent-router.test.ts
+++ b/packages/agent-router/tests/agent-router.test.ts
@@ -252,6 +252,7 @@ const TestAgentRouterLive = Layer.effect(
   }),
 );
 
+
 const provideRouter = <A>(
   effect: Effect.Effect<A, never, CacheServiceInterface>,
 ) =>
@@ -260,14 +261,14 @@ const provideRouter = <A>(
   );
 
 describe("AgentRouter", () => {
-  test("initializes with default agents", async () => {
+  test.serial("initializes with default agents", async () => {
     const agents = await Effect.runPromise(provideRouter(getAgents));
 
     expect(agents.length).toBeGreaterThan(0);
     expect(agents.find((agent) => agent.name === "claude-code")).toBeDefined();
   });
 
-  test("activates agents via effect", async () => {
+  test.serial("activates agents via effect", async () => {
     const activeAgents = await Effect.runPromise(
       provideRouter(
         Effect.gen(function* () {
@@ -280,7 +281,7 @@ describe("AgentRouter", () => {
     expect(activeAgents.some((agent) => agent.name === "opencode")).toBe(true);
   });
 
-  test("routes queries based on CLI path", async () => {
+  test.serial("routes queries based on CLI path", async () => {
     const response = await Effect.runPromise(
       provideRouter(
         Effect.gen(function* () {
@@ -296,7 +297,7 @@ describe("AgentRouter", () => {
     expect(response.agent).toBe("opencode");
   });
 
-  test("falls back to default agent", async () => {
+  test.serial("falls back to default agent", async () => {
     const response = await Effect.runPromise(
       provideRouter(
         routeQuery({
@@ -309,7 +310,7 @@ describe("AgentRouter", () => {
     expect(response.agent).toBe("claude-code");
   });
 
-  test("executes squad mode", async () => {
+  test.serial("executes squad mode", async () => {
     const responses = await Effect.runPromise(
       provideRouter(
         Effect.gen(function* () {

--- a/packages/cache/tests/cache.test.ts
+++ b/packages/cache/tests/cache.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { AgentCache } from "../src/index.js";
 
-describe("Cache", () => {
-  it("should define AgentCache interface", () => {
+describe.concurrent("Cache", () => {
+  test.concurrent("should define AgentCache interface", async () => {
     const cache: AgentCache = {
       agents: [
         {
@@ -20,7 +20,7 @@ describe("Cache", () => {
     expect(cache.lastUpdated).toBe("2024-01-01T00:00:00.000Z");
   });
 
-  it("should allow empty agent cache", () => {
+  test.concurrent("should allow empty agent cache", async () => {
     const cache: AgentCache = {
       agents: [],
       lastUpdated: "2024-01-01T00:00:00.000Z",

--- a/packages/config/tests/config.test.ts
+++ b/packages/config/tests/config.test.ts
@@ -1,27 +1,34 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { defaultConfig, type UserConfig } from "../src/index.js";
 
-describe("Config", () => {
-  it("should have a default config", () => {
+
+const requiredFields = [
+  ["version", "1.0.0"],
+  ["createdAt", "2024-01-01T00:00:00.000Z"],
+  ["updatedAt", "2024-01-01T00:00:00.000Z"],
+] as const;
+
+describe.concurrent("Config", () => {
+  test.concurrent("should have a default config", async () => {
     expect(defaultConfig).toBeDefined();
     expect(defaultConfig.version).toBe("1.0.0");
     expect(defaultConfig.createdAt).toBeDefined();
     expect(defaultConfig.updatedAt).toBeDefined();
   });
 
-  it("should have required fields in UserConfig", () => {
+  test.concurrent("should require core fields in UserConfig", async () => {
     const config: UserConfig = {
       version: "1.0.0",
       createdAt: "2024-01-01T00:00:00.000Z",
       updatedAt: "2024-01-01T00:00:00.000Z",
     };
 
-    expect(config.version).toBe("1.0.0");
-    expect(config.createdAt).toBe("2024-01-01T00:00:00.000Z");
-    expect(config.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    for (const [field, expected] of requiredFields) {
+      expect(config).toHaveProperty(field, expected);
+    }
   });
 
-  it("should allow optional telemetry config", () => {
+  test.concurrent("should allow optional telemetry config", async () => {
     const config: UserConfig = {
       ...defaultConfig,
       telemetry: {

--- a/packages/db/tests/database.test.ts
+++ b/packages/db/tests/database.test.ts
@@ -8,6 +8,7 @@ let dbModule: typeof import("../src/index");
 let tempDir: string;
 let tempFile: string;
 
+
 beforeAll(async () => {
   tempDir = mkdtempSync(path.join(tmpdir(), "open-composer-db-"));
   tempFile = path.join(tempDir, "app.db");
@@ -21,11 +22,11 @@ afterAll(() => {
 });
 
 describe("Database layer", () => {
-  test("uses the configured sqlite file", () => {
+  test.serial("uses the configured sqlite file", () => {
     expect(dbModule.databaseFile.value).toBe(tempFile);
   });
 
-  test("runs migrations and supports drizzle queries", async () => {
+  test.serial("runs migrations and supports drizzle queries", async () => {
     // Run migrations manually
     const migration = (await import("../migrations/0000_create_settings"))
       .default;
@@ -51,7 +52,7 @@ describe("Database layer", () => {
     );
   });
 
-  test("creates database snapshot", async () => {
+  test.serial("creates database snapshot", async () => {
     const snapshot = await Effect.runPromise(
       dbModule.createDatabaseSnapshot.pipe(
         Effect.provide(dbModule.DatabaseLive),
@@ -67,7 +68,7 @@ describe("Database layer", () => {
     expect(typeof snapshot.timestamp).toBe("string");
   });
 
-  test("creates and restores settings snapshot", async () => {
+  test.serial("creates and restores settings snapshot", async () => {
     // First clear any existing data
     const clearProgram = Effect.gen(function* () {
       const db = yield* dbModule.SqliteDrizzle;
@@ -138,7 +139,7 @@ describe("Database layer", () => {
     expect(restoredData.find((s) => s.key === "test2")?.value).toBe("value2");
   });
 
-  test("gets migration status", async () => {
+  test.serial("gets migration status", async () => {
     const status = await Effect.runPromise(
       dbModule.getMigrationStatus.pipe(Effect.provide(dbModule.DatabaseLive)),
     );
@@ -157,7 +158,7 @@ describe("Database layer", () => {
     }
   });
 
-  test("validates database schema", async () => {
+  test.serial("validates database schema", async () => {
     const validation = await Effect.runPromise(
       dbModule.validateDatabaseSchema.pipe(
         Effect.provide(dbModule.DatabaseLive),
@@ -176,7 +177,7 @@ describe("Database layer", () => {
     expect(validation.errors).toHaveLength(0);
   });
 
-  test("validates database schema with missing table", async () => {
+  test.serial("validates database schema with missing table", async () => {
     // Test validation against a non-existent database
     const tempDbPath = path.join(tempDir, "non-existent.db");
 

--- a/packages/db/tests/migrations.test.ts
+++ b/packages/db/tests/migrations.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -14,6 +6,7 @@ import { Effect } from "effect";
 
 let tempDir: string;
 let dbFile: string;
+
 
 beforeAll(async () => {
   tempDir = mkdtempSync(path.join(tmpdir(), "open-composer-migrations-"));
@@ -51,7 +44,7 @@ describe("Migration Functionality", () => {
   });
 
   describe("Database Initialization", () => {
-    test("initializes database with migrations", async () => {
+    test.serial("initializes database with migrations", async () => {
       const program = Effect.gen(function* () {
         // Initialize database should run all migrations
         yield* dbModule.initializeDatabase;
@@ -86,7 +79,7 @@ describe("Migration Functionality", () => {
       expect(result.value.migrations.length).toBeGreaterThan(0); // Migrations ran successfully
     });
 
-    test("creates proper directory structure", async () => {
+    test.serial("creates proper directory structure", async () => {
       const program = Effect.gen(function* () {
         yield* dbModule.initializeDatabase;
 
@@ -116,7 +109,7 @@ describe("Migration Functionality", () => {
   });
 
   describe("Migration Status Tracking", () => {
-    test("tracks migration execution correctly", async () => {
+    test.serial("tracks migration execution correctly", async () => {
       const program = Effect.gen(function* () {
         // After initialization
         yield* dbModule.initializeDatabase;
@@ -143,7 +136,7 @@ describe("Migration Functionality", () => {
   });
 
   describe("Schema Validation", () => {
-    test("validates complete database schema", async () => {
+    test.serial("validates complete database schema", async () => {
       const program = Effect.gen(function* () {
         yield* dbModule.initializeDatabase;
         const validation = yield* dbModule.validateDatabaseSchema;
@@ -166,7 +159,7 @@ describe("Migration Functionality", () => {
   });
 
   describe("Settings Snapshot", () => {
-    test("creates settings snapshot", async () => {
+    test.serial("creates settings snapshot", async () => {
       const program = Effect.gen(function* () {
         yield* dbModule.initializeDatabase;
 
@@ -185,7 +178,7 @@ describe("Migration Functionality", () => {
       );
     });
 
-    test("restores settings snapshot", async () => {
+    test.serial("restores settings snapshot", async () => {
       const program = Effect.gen(function* () {
         yield* dbModule.initializeDatabase;
 

--- a/packages/gh-pr/tests/gh-pr.test.ts
+++ b/packages/gh-pr/tests/gh-pr.test.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { createPR, getPRStatus } from "../src/index.js";
 
-describe("GitHub PR Package", () => {
-  describe("createPR", () => {
-    it("should export createPR function", () => {
+
+describe.concurrent("GitHub PR Package", () => {
+  describe.concurrent("createPR", () => {
+    test.concurrent("should export createPR function", () => {
       expect(typeof createPR).toBe("function");
     });
 
-    it("should create PR effect", () => {
+    test.concurrent("should create PR effect", () => {
       const prOptions = {
         title: "Test PR",
         body: "Test body",
@@ -23,12 +24,12 @@ describe("GitHub PR Package", () => {
     });
   });
 
-  describe("getPRStatus", () => {
-    it("should export getPRStatus function", () => {
+  describe.concurrent("getPRStatus", () => {
+    test.concurrent("should export getPRStatus function", () => {
       expect(typeof getPRStatus).toBe("function");
     });
 
-    it("should create status effect", () => {
+    test.concurrent("should create status effect", () => {
       const effect = getPRStatus(123);
       expect(effect).toBeDefined();
     });

--- a/packages/gh/tests/gh.test.ts
+++ b/packages/gh/tests/gh.test.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { run } from "../src/index.js";
 
-describe("GitHub CLI Package", () => {
-  describe("run", () => {
-    it("should export run function", () => {
+
+describe.concurrent("GitHub CLI Package", () => {
+  describe.concurrent("run", () => {
+    test.concurrent("should export run function", async () => {
       expect(typeof run).toBe("function");
     });
 
-    it("should create an Effect for GitHub commands", () => {
+    test.concurrent("should create an Effect for GitHub commands", async () => {
       const effect = run(["--help"]);
       expect(effect).toBeDefined();
       // Note: We don't run the effect as it would require gh CLI
@@ -16,8 +17,8 @@ describe("GitHub CLI Package", () => {
 
   // Note: Actual CLI tests would require gh CLI to be installed
   // and authenticated, which is not suitable for CI
-  describe("commands", () => {
-    it("should export authStatus", async () => {
+  describe.concurrent("commands", () => {
+    test.concurrent("should export authStatus", async () => {
       const { authStatus } = await import("../src/commands.js");
       expect(typeof authStatus).toBe("object");
     });

--- a/packages/git-stack/tests/git-stack.test.ts
+++ b/packages/git-stack/tests/git-stack.test.ts
@@ -19,6 +19,7 @@ import {
 let testDir: string;
 let originalCwd: string;
 
+
 // Helper to run effects that can fail and extract the value
 const runEffect = async <A>(
   effect: Effect.Effect<A, GitCommandError>,
@@ -59,13 +60,13 @@ describe("GitStack", () => {
     await cleanupTestRepo(testDir);
   });
 
-  test("log returns helpful message when stack is empty", async () => {
+  test.serial("log returns helpful message when stack is empty", async () => {
     process.chdir(testDir);
     const lines = await runEffect(runWithGitStack(logStack));
     expect(lines[0]).toContain("No tracked stack branches");
   });
 
-  test("create branch and track it in stack", async () => {
+  test.serial("create branch and track it in stack", async () => {
     process.chdir(testDir);
 
     // Get the initial branch name for tracking
@@ -110,7 +111,7 @@ describe("GitStack", () => {
     );
   });
 
-  test("track multiple branches and show stack", async () => {
+  test.serial("track multiple branches and show stack", async () => {
     process.chdir(testDir);
 
     // Get the initial branch name for tracking
@@ -169,7 +170,7 @@ describe("GitStack", () => {
     ).toBe(true);
   });
 
-  test("status shows current branch and relationships", async () => {
+  test.serial("status shows current branch and relationships", async () => {
     process.chdir(testDir);
 
     // Get the initial branch name for tracking
@@ -196,7 +197,7 @@ describe("GitStack", () => {
     expect(status.currentBranch).toBe("test-branch");
   });
 
-  test("untrack removes branch from stack", async () => {
+  test.serial("untrack removes branch from stack", async () => {
     process.chdir(testDir);
 
     // Get the initial branch name for tracking

--- a/packages/git-worktrees/tests/worktrees.test.ts
+++ b/packages/git-worktrees/tests/worktrees.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import * as Effect from "effect/Effect";
 import { add, list, lock, move, remove } from "../src/worktrees.js";
 import { createGitStub, success } from "./utils.js";
 
-describe("git worktrees", () => {
-  it("parses porcelain worktree listings", async () => {
+
+describe.concurrent("git worktrees", () => {
+  test.concurrent("parses porcelain worktree listings", async () => {
     const porcelain = [
       "worktree /repo/main",
       "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -40,7 +41,7 @@ describe("git worktrees", () => {
     });
   });
 
-  it("creates worktrees with branching and locking", async () => {
+  test.concurrent("creates worktrees with branching and locking", async () => {
     const porcelain = [
       "worktree /repo/main",
       "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -89,7 +90,7 @@ describe("git worktrees", () => {
     });
   });
 
-  it("propagates not-found errors after move", async () => {
+  test.concurrent("propagates not-found errors after move", async () => {
     const stub = createGitStub([
       success(""),
       success("worktree /repo/main\n\n"),
@@ -114,7 +115,7 @@ describe("git worktrees", () => {
     }
   });
 
-  it("removes worktrees", async () => {
+  test.concurrent("removes worktrees", async () => {
     const stub = createGitStub([success("")]);
 
     await Effect.runPromise(
@@ -129,7 +130,7 @@ describe("git worktrees", () => {
     ]);
   });
 
-  it("locks worktrees with reasons", async () => {
+  test.concurrent("locks worktrees with reasons", async () => {
     const porcelain = [
       "worktree /repo/feature/foo",
       "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/packages/git/tests/git.test.ts
+++ b/packages/git/tests/git.test.ts
@@ -1,22 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { Git, getCurrentBranch, log, status } from "../src/index.js";
 
-describe("Git Core", () => {
-  test("should export Git context tag", () => {
+
+const gitCommands = [
+  ["status", status],
+  ["log", log],
+  ["getCurrentBranch", getCurrentBranch],
+] as const;
+
+describe.concurrent("Git Core", () => {
+  test.concurrent("should export Git context tag", async () => {
     expect(Git).toBeDefined();
     expect(Git).toHaveProperty("key");
     expect(Git.key).toBe("@open-composer/git/Git");
   });
 
-  test("should have git commands available", () => {
-    expect(status).toBeDefined();
-    expect(log).toBeDefined();
-    expect(getCurrentBranch).toBeDefined();
-  });
-
-  test("git commands should be functions", () => {
-    expect(typeof status).toBe("function");
-    expect(typeof log).toBe("function");
-    expect(typeof getCurrentBranch).toBe("function");
-  });
+  for (const [name, command] of gitCommands) {
+    test.concurrent(`should expose ${name} command as a function`, async () => {
+      expect(command).toBeDefined();
+      expect(typeof command).toBe("function");
+    });
+  }
 });

--- a/packages/tmux/tests/tmux.test.ts
+++ b/packages/tmux/tests/tmux.test.ts
@@ -1,20 +1,21 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
 import { TmuxService } from "../src/core.js";
 
+
 describe("TmuxService", () => {
-  it("should create a service instance", async () => {
+  test.serial("should create a service instance", async () => {
     const result = await Effect.runPromise(TmuxService.make());
     expect(result).toBeInstanceOf(TmuxService);
   });
 
-  it("should check if tmux is available", async () => {
+  test.serial("should check if tmux is available", async () => {
     const service = await Effect.runPromise(TmuxService.make());
     const result = await Effect.runPromise(service.isAvailable());
     expect(typeof result).toBe("boolean");
   });
 
-  it("should handle tmux command errors gracefully", async () => {
+  test.serial("should handle tmux command errors gracefully", async () => {
     const service = await Effect.runPromise(TmuxService.make());
 
     // Try to get PID of non-existent session


### PR DESCRIPTION
## Summary
- replace the ad-hoc Bun concurrency wrappers with direct calls to `describe.concurrent`, `test.concurrent`, and `test.serial`
- update CLI and package test suites to import `test` directly and rely on Bun's native concurrent and serial helpers

## Testing
- bun test packages/cache/tests/cache.test.ts *(fails: Bun 1.2.14 in this environment does not expose describe.concurrent yet)*

------
https://chatgpt.com/codex/tasks/task_e_68daf4c821ac832484447c62cfa22284