### PR TITLE
Remove description fields from package.json files

### DIFF
--- a/agents/claude-code/package.json
+++ b/agents/claude-code/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/agent-claude-code",
   "version": "0.1.0",
-  "description": "Claude Code agent for Anthropic's coding assistant",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/agents/codex/package.json
+++ b/agents/codex/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/agent-codex",
   "version": "0.1.0",
-  "description": "Codex agent for GitHub Copilot CLI integration",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/agents/opencode/package.json
+++ b/agents/opencode/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/agent-opencode",
   "version": "0.1.0",
-  "description": "OpenCode agent for open-source coding assistance",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/agents/types/package.json
+++ b/agents/types/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/agent-types",
   "version": "0.1.0",
-  "description": "OpenCode agent for open-source coding assistance",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/cache",
   "version": "0.1.0",
-  "description": "Caching functionality for Open Composer",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/config",
   "version": "0.2.0",
-  "description": "Configuration management for Open Composer",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",

--- a/workers/posthog/package.json
+++ b/workers/posthog/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@open-composer/posthog-worker",
   "version": "1.0.3",
-  "description": "Cloudflare Worker for anonymous PostHog logging with IP-based rate limiting",
   "repository": "https://github.com/shunkakinoki/open-composer",
   "license": "MIT",
   "author": "Shun Kakinoki",


### PR DESCRIPTION
This PR removes the description fields from various package.json files across the codebase that were previously present.

## Changes
- Removed description fields from:
  - agents/claude-code/package.json
  - agents/codex/package.json
  - agents/opencode/package.json
  - agents/types/package.json
  - packages/cache/package.json
  - packages/config/package.json
  - workers/posthog/package.json

## Purpose
This change aligns with the project's approach of removing redundant description fields from package.json files, maintaining a cleaner configuration while preserving all other metadata.