### PR TITLE
feat: db layer migration

### DIFF
--- a/packages/db/tests/database.test.ts
+++ b/packages/db/tests/database.test.ts
@@ -60,10 +60,13 @@ describe("Database layer", () => {
       yield* dbModule.initializeDatabase;
       const db = yield* dbModule.SqliteDrizzle;
       // Ensure clean state
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
       yield* db.delete(dbModule.settings as any);
       yield* db
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
         .insert(dbModule.settings as any)
         .values({ key: "theme", value: "dark" });
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
       return yield* db.select().from(dbModule.settings as any);
     });
 
@@ -108,9 +111,11 @@ describe("Database layer", () => {
 
       // First clear any existing data
       const db = yield* dbModule.SqliteDrizzle;
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
       yield* db.delete(dbModule.settings as any);
 
       // Add some test data
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
       yield* db.insert(dbModule.settings as any).values([
         { key: "test1", value: "value1" },
         { key: "test2", value: "value2" },
@@ -124,6 +129,7 @@ describe("Database layer", () => {
       expect(snapshot.settings).toHaveLength(2);
 
       // Clear existing data again before restore
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
       yield* db.delete(dbModule.settings as any);
 
       // Restore from snapshot
@@ -132,7 +138,9 @@ describe("Database layer", () => {
       // Verify data was restored
       const restoredData = yield* db
         .select()
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
         .from(dbModule.settings as any)
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle type incompatibility
         .orderBy(dbModule.settings.key as any);
 
       expect(restoredData).toHaveLength(2);

--- a/packages/db/tests/database.test.ts
+++ b/packages/db/tests/database.test.ts
@@ -64,9 +64,7 @@ describe("Database layer", () => {
       yield* db
         .insert(dbModule.settings as any)
         .values({ key: "theme", value: "dark" });
-      return yield* db
-        .select()
-        .from(dbModule.settings as any);
+      return yield* db.select().from(dbModule.settings as any);
     });
 
     const result = await (

--- a/packages/db/tests/migrations.test.ts
+++ b/packages/db/tests/migrations.test.ts
@@ -121,7 +121,7 @@ describe("Migration Functionality", () => {
 
         // Verify migration details
         expect(afterStatus.migrations.length).toBeGreaterThan(0);
-        afterStatus.migrations.forEach((migration: any) => {
+        afterStatus.migrations.forEach((migration) => {
           expect(migration).toHaveProperty("id");
           expect(migration).toHaveProperty("name");
           expect(migration).toHaveProperty("createdAt");


### PR DESCRIPTION
- Added biome-ignore comments to suppress type warnings related to explicit 'any' usage in database operations.
- Ensured that the database tests maintain functionality while addressing type safety concerns.