### PR TITLE
fix: resolve Docker container startup issues

### DIFF
--- a/.changeset/fix-docker-git-config.md
+++ b/.changeset/fix-docker-git-config.md
@@ -2,4 +2,4 @@
 "open-composer": patch
 ---
 
-Fix Docker container git configuration permissions issue by ensuring proper directory ownership for the runner user.
+Fix Docker container git configuration permissions issue by ensuring proper directory ownership for the runner user and setting bash as the default shell for RUN commands.

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/shunkakinoki/dotfiles:sha-d655c4a
 
+# Use bash as shell for RUN commands
+SHELL ["/bin/bash", "-c"]
+
 # Fix git config permissions issue
 RUN mkdir -p /home/runner/.config/git && \
     chown -R runner:runner /home/runner/.config


### PR DESCRIPTION
## Changes Made
- Set bash as default shell for RUN commands to prevent fish shell errors
- Ensure proper directory ownership for runner user git config
- Fix container initialization that was failing due to missing fish shell

## Technical Details
- Added SHELL directive to use bash instead of default fish shell in Dockerfile
- Modified .cursor/Dockerfile to include shell configuration
- Maintains existing git config permissions fix from previous PR

## Testing
- All pre-commit hooks pass (build, test, linting, formatting)
- Container should now start without shell or permission errors
- Development environment setup remains intact

🤖 Generated with Cursor by Claude