### PR TITLE
feat: add static migration handling and update migration logic

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist/**/*",
     "src/**/*",
+    "migrations/**/*",
     "README.md",
     "CHANGELOG.md"
   ],


### PR DESCRIPTION
## Summary
- Add static migration handling to avoid filesystem reads in compiled binaries
- Update migration logic to use a static list of migrations instead of dynamically reading files
- Include migrations directory in package files to ensure migrations are bundled

## Changes
- Modified database initialization to use static imports for migration files
- Replaced dynamic file reading with predefined migration array
- Added migrations directory to package.json files array