### PR TITLE
feat: add type-check script to package.json for multiple agents

### DIFF
--- a/agents/claude-code/package.json
+++ b/agents/claude-code/package.json
@@ -17,7 +17,8 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target=node",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "bun test"
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@open-composer/agent-types": "workspace:*",

--- a/agents/codex/package.json
+++ b/agents/codex/package.json
@@ -17,7 +17,8 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target=node",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "bun test"
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@open-composer/agent-types": "workspace:*",

--- a/agents/opencode/package.json
+++ b/agents/opencode/package.json
@@ -17,7 +17,8 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target=node",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "bun test"
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@open-composer/agent-types": "workspace:*",

--- a/agents/types/package.json
+++ b/agents/types/package.json
@@ -17,7 +17,8 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target=node",
     "lint": "biome check .",
     "lint:fix": "tsc",
-    "test": "bun test"
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "effect": "^3.18.0"

--- a/apps/cli/src/commands/gh-pr-command.ts
+++ b/apps/cli/src/commands/gh-pr-command.ts
@@ -38,7 +38,7 @@ export const buildGHPRCommand = (): CommandBuilder<"pr"> => ({
 // -----------------------------------------------------------------------------
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
+  Effect.forEach(lines, (line) => Console.log(line), {
     discard: true,
   });
 

--- a/apps/cli/src/commands/gh-pr-command.ts
+++ b/apps/cli/src/commands/gh-pr-command.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Options } from "@effect/cli";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { GhPRService } from "../services/gh-pr-service.js";
@@ -37,7 +38,7 @@ export const buildGHPRCommand = (): CommandBuilder<"pr"> => ({
 // -----------------------------------------------------------------------------
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => console.log(line)), {
+  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
     discard: true,
   });
 

--- a/apps/cli/src/commands/git-worktree-command.ts
+++ b/apps/cli/src/commands/git-worktree-command.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import path from "node:path";
+import * as path from "node:path";
 import { promisify } from "node:util";
 import { Args, Command, Options } from "@effect/cli";
 import * as Effect from "effect/Effect";
@@ -285,11 +285,13 @@ function buildCreateCommand() {
           yield* _(
             cli.create({
               path: options.path,
-              ref: options.ref || undefined,
-              branch: options.branch || undefined,
+              ...(options.ref && { ref: options.ref }),
+              ...(options.branch && { branch: options.branch }),
               force: options.force,
               detach: options.detach,
-              checkout: options.noCheckout ? false : undefined,
+              ...(options.noCheckout !== undefined && {
+                checkout: !options.noCheckout,
+              }),
               branchForce: options.branchForce,
             }),
           );
@@ -315,11 +317,15 @@ function buildCreateCommand() {
         yield* _(
           cli.create({
             path: Option.getOrElse(config.path, () => ""),
-            ref: config.ref.pipe(Option.getOrUndefined),
-            branch: config.branch.pipe(Option.getOrUndefined),
+            ...(Option.isSome(config.ref) && {
+              ref: Option.getOrThrow(config.ref),
+            }),
+            ...(Option.isSome(config.branch) && {
+              branch: Option.getOrThrow(config.branch),
+            }),
             force: config.force,
             detach: config.detach,
-            checkout: config.noCheckout ? false : undefined,
+            ...(config.noCheckout && { checkout: false }),
             branchForce: config.branchForce,
           }),
         );
@@ -412,7 +418,9 @@ function buildPruneCommand() {
           cli.prune({
             dryRun: config.dryRun,
             verbose: config.verbose,
-            expire: config.expire.pipe(Option.getOrUndefined),
+            ...(Option.isSome(config.expire) && {
+              expire: Option.getOrThrow(config.expire),
+            }),
           }),
         );
 

--- a/apps/cli/src/commands/run-command.ts
+++ b/apps/cli/src/commands/run-command.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import * as path from "node:path";
 import { Args, Command, Options } from "@effect/cli";
 import {
   type AgentChecker,

--- a/apps/cli/src/services/agent-service.ts
+++ b/apps/cli/src/services/agent-service.ts
@@ -21,14 +21,7 @@ interface RouteOptions {
 }
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(
-    lines,
-    (line) =>
-      Effect.sync(() => {
-        Console.log(line);
-      }),
-    { discard: true },
-  );
+  Effect.forEach(lines, (line) => Console.log(line), { discard: true });
 
 const defaultCliPath = () => ["open-composer"] as const;
 

--- a/apps/cli/src/services/agent-service.ts
+++ b/apps/cli/src/services/agent-service.ts
@@ -7,6 +7,7 @@ import {
   routeQuery,
 } from "@open-composer/agent-router";
 import type { CacheServiceInterface } from "@open-composer/cache";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 
 interface ListOptions {
@@ -24,7 +25,7 @@ const printLines = (lines: ReadonlyArray<string>) =>
     lines,
     (line) =>
       Effect.sync(() => {
-        console.log(line);
+        Console.log(line);
       }),
     { discard: true },
   );

--- a/apps/cli/src/services/git-worktree-service.ts
+++ b/apps/cli/src/services/git-worktree-service.ts
@@ -268,11 +268,9 @@ export class GitWorktreeService {
   private printGitWorktreeLines(
     lines: ReadonlyArray<string>,
   ): Effect.Effect<void, never> {
-    return Effect.forEach(
-      lines,
-      (line) => Effect.sync(() => Console.log(line)),
-      { discard: true },
-    );
+    return Effect.forEach(lines, (line) => Console.log(line), {
+      discard: true,
+    });
   }
 
   switch(worktreePath: string): Effect.Effect<void, Error, GitService> {

--- a/apps/cli/src/services/sessions-service.ts
+++ b/apps/cli/src/services/sessions-service.ts
@@ -1,10 +1,11 @@
 import { type Session, SqliteDrizzle, sessions } from "@open-composer/db";
 import { desc, eq } from "drizzle-orm";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import { StackService } from "./stack-service.js";
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => console.log(line)), {
+  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
     discard: true,
   });
 
@@ -112,10 +113,10 @@ export class SessionsService {
               output: process.stdout,
             });
 
-            console.log("\nChoose workspace option:");
-            console.log("1. Use existing git workspace");
-            console.log("2. Create new workspace");
-            console.log("3. No workspace (just session tracking)");
+            Console.log("\nChoose workspace option:");
+            Console.log("1. Use existing git workspace");
+            Console.log("2. Create new workspace");
+            Console.log("3. No workspace (just session tracking)");
 
             rl.question("Enter choice (1-3): ", (choice) => {
               rl.close();
@@ -166,7 +167,7 @@ export class SessionsService {
                       rl.close();
                       resolve(resolvedPath);
                     } catch {
-                      console.log(
+                      Console.log(
                         `❌ "${resolvedPath}" is not a valid git repository.`,
                       );
                       promptPath();

--- a/apps/cli/src/services/sessions-service.ts
+++ b/apps/cli/src/services/sessions-service.ts
@@ -5,9 +5,7 @@ import * as Effect from "effect/Effect";
 import { StackService } from "./stack-service.js";
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
-    discard: true,
-  });
+  Effect.forEach(lines, (line) => Console.log(line), { discard: true });
 
 export class SessionsService {
   /**
@@ -113,10 +111,10 @@ export class SessionsService {
               output: process.stdout,
             });
 
-            Console.log("\nChoose workspace option:");
-            Console.log("1. Use existing git workspace");
-            Console.log("2. Create new workspace");
-            Console.log("3. No workspace (just session tracking)");
+            console.log("\nChoose workspace option:");
+            console.log("1. Use existing git workspace");
+            console.log("2. Create new workspace");
+            console.log("3. No workspace (just session tracking)");
 
             rl.question("Enter choice (1-3): ", (choice) => {
               rl.close();
@@ -167,7 +165,7 @@ export class SessionsService {
                       rl.close();
                       resolve(resolvedPath);
                     } catch {
-                      Console.log(
+                      console.log(
                         `❌ "${resolvedPath}" is not a valid git repository.`,
                       );
                       promptPath();

--- a/apps/cli/src/services/stack-service.ts
+++ b/apps/cli/src/services/stack-service.ts
@@ -13,10 +13,11 @@ import {
   trackStackBranch,
   untrackStackBranch,
 } from "@open-composer/git-stack";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => console.log(line)), {
+  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
     discard: true,
   });
 
@@ -30,9 +31,9 @@ const provideStack = <A, E>(effectFn: () => Effect.Effect<A, E>) => {
 
 const handleGitError = (error: GitCommandError): Effect.Effect<void> =>
   Effect.sync(() => {
-    console.error(`Git command failed: ${error.message}`);
+    Console.error(`Git command failed: ${error.message}`);
     if (error.stderr) {
-      console.error(error.stderr);
+      Console.error(error.stderr);
     }
   });
 

--- a/apps/cli/src/services/stack-service.ts
+++ b/apps/cli/src/services/stack-service.ts
@@ -17,9 +17,7 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 
 const printLines = (lines: ReadonlyArray<string>) =>
-  Effect.forEach(lines, (line) => Effect.sync(() => Console.log(line)), {
-    discard: true,
-  });
+  Effect.forEach(lines, (line) => Console.log(line), { discard: true });
 
 const provideStack = <A, E>(effectFn: () => Effect.Effect<A, E>) => {
   // In test environment, run the effect and wrap the result in a new Effect
@@ -30,10 +28,10 @@ const provideStack = <A, E>(effectFn: () => Effect.Effect<A, E>) => {
 };
 
 const handleGitError = (error: GitCommandError): Effect.Effect<void> =>
-  Effect.sync(() => {
-    Console.error(`Git command failed: ${error.message}`);
+  Effect.gen(function* () {
+    yield* Console.error(`Git command failed: ${error.message}`);
     if (error.stderr) {
-      Console.error(error.stderr);
+      yield* Console.error(error.stderr);
     }
   });
 

--- a/apps/cli/tests/services/gh-pr-service.test.ts
+++ b/apps/cli/tests/services/gh-pr-service.test.ts
@@ -8,7 +8,7 @@ import {
   test,
 } from "bun:test";
 import { existsSync } from "node:fs";
-import path from "node:path";
+import * as path from "node:path";
 import * as Effect from "effect/Effect";
 
 // Mock external dependencies before importing the service

--- a/packages/gh-pr/src/index.ts
+++ b/packages/gh-pr/src/index.ts
@@ -76,7 +76,7 @@ export const createPR = (options: PRCreateOptions) =>
         yield* run(["pr", "merge", prNumber.toString(), "--squash", "--auto"]);
         autoMergeEnabled = true;
       } catch (error) {
-        Console.warn(`Warning: Could not enable auto-merge: ${error}`);
+        yield* Console.warn(`Warning: Could not enable auto-merge: ${error}`);
       }
     }
 

--- a/packages/gh-pr/src/index.ts
+++ b/packages/gh-pr/src/index.ts
@@ -3,6 +3,7 @@ import {
   type GitHubCommandResult,
   run,
 } from "@open-composer/gh";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 
 // Types
@@ -75,7 +76,7 @@ export const createPR = (options: PRCreateOptions) =>
         yield* run(["pr", "merge", prNumber.toString(), "--squash", "--auto"]);
         autoMergeEnabled = true;
       } catch (error) {
-        console.warn(`Warning: Could not enable auto-merge: ${error}`);
+        Console.warn(`Warning: Could not enable auto-merge: ${error}`);
       }
     }
 


### PR DESCRIPTION
- Added "type-check": "tsc --noEmit" script to package.json files for claude-code, codex, opencode, and types agents.
- Updated console logging to use effect/Console in various CLI services for consistency and improved logging practices.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new "type-check" script to agent packages and switched CLI logging to effect/Console for consistent, structured output.

- **New Features**
  - Added "type-check": "tsc --noEmit" to claude-code, codex, opencode, and types agents.

- **Refactors**
  - Replaced console.* with effect/Console in CLI commands, services, gh-pr, and process-runner.
  - Cleaned up option handling in git-worktree create/prune to pass only defined values.
  - Updated Node path imports to "import * as path" for consistency.

<!-- End of auto-generated description by cubic. -->

