### PR TITLE
feat(cli): add tests for upgrade command functionality

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -58,10 +58,40 @@ jobs:
         continue-on-error: true
         run: open-composer --version
         shell: cmd
+  install-e2e-script:
+    if: (github.event.release.tag_name && startsWith(github.event.release.tag_name, 'open-composer@')) || (github.event.inputs.tag && startsWith(github.event.inputs.tag, 'open-composer@')) || github.event_name == 'schedule'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        arch:
+          - x64
+          - arm64
+      fail-fast: false
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || github.ref }}
+      - name: Test install.sh script
+        run: bash install.sh
+        shell: bash
+      - name: Verify open-composer command after script install
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          open-composer --version
+        shell: bash
   install-check:
     if: always()
     needs:
       - install-e2e-cli
+      - install-e2e-script
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -69,4 +99,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: install-e2e-cli
+          allowed-skips: install-e2e-cli,install-e2e-script

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # open-composer
 Chat-first CLI tool for orchestrating multiple AI agents and Git worktrees with ease.
+
+## Installation
+
+### Quick Install (Unix/Linux/macOS)
+
+```bash
+curl -fsSL https://opencomposer.ai/install | bash
+```
+
+Or directly from GitHub:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shunkakinoki/open-composer/main/install.sh | bash
+```
+
+### Via npm
+
+```bash
+npm install -g open-composer
+```
+
+### Manual Installation
+
+1. Download the appropriate binary for your platform from the [latest release](https://github.com/shunkakinoki/open-composer/releases/latest)
+2. Extract the archive
+3. Move the binary to a directory in your PATH
+
+## Upgrading
+
+To upgrade to the latest version:
+
+```bash
+open-composer upgrade
+```
+
+Check for updates without installing:
+
+```bash
+open-composer upgrade --check
+```
+
+Upgrade to a specific version:
+
+```bash
+open-composer upgrade 0.8.3
+```

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,6 +42,7 @@
     "@open-composer/gh": "workspace:*",
     "@open-composer/gh-pr": "workspace:*",
     "@open-composer/git": "workspace:*",
+    "@open-composer/git-releases": "workspace:*",
     "@open-composer/git-stack": "workspace:*",
     "@open-composer/git-worktrees": "workspace:*",
     "@open-composer/process-runner": "workspace:*",

--- a/apps/cli/src/commands/composer-command.ts
+++ b/apps/cli/src/commands/composer-command.ts
@@ -40,6 +40,7 @@ import { buildStackCommand } from "./stack-command.js";
 import { buildStatusCommand } from "./status-command.js";
 import { buildTelemetryCommand } from "./telemetry-command.js";
 import { buildTUICommand } from "./tui-command.js";
+import { buildUpgradeCommand } from "./upgrade-command.js";
 
 // -----------------------------------------------------------------------------
 // Types
@@ -93,6 +94,7 @@ const ALL_COMMAND_BUILDERS = [
   buildStatusCommand,
   buildTelemetryCommand,
   buildTUICommand,
+  buildUpgradeCommand,
 ];
 
 const EXCLUDED_HELP_TEXT_NAMES = ["cache", "config"];

--- a/apps/cli/src/commands/run-command.ts
+++ b/apps/cli/src/commands/run-command.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import * as path from "node:path";
 import { Args, Command, Options } from "@effect/cli";
 import {
   type AgentChecker,
@@ -275,7 +275,7 @@ function createWorktreeAndRunAgent(
       branchName,
       worktreePath,
       sessionName,
-      prNumber,
+      ...(prNumber !== undefined && { prNumber }),
       changes,
     };
   });

--- a/apps/cli/src/commands/upgrade-command.ts
+++ b/apps/cli/src/commands/upgrade-command.ts
@@ -1,0 +1,440 @@
+import { chmod, mkdir, realpath, rename, rm } from "node:fs/promises";
+import { arch, homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { Args, Command, Options } from "@effect/cli";
+import {
+  compareVersions,
+  GitHubReleases,
+  makeGitHubReleasesLive,
+} from "@open-composer/git-releases";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import { CLI_VERSION } from "../lib/version.js";
+import { trackFeatureUsage } from "../services/telemetry-service.js";
+import type { CommandBuilder } from "../types/commands.js";
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const GITHUB_OWNER = "shunkakinoki";
+const GITHUB_REPO = "open-composer";
+const PACKAGE_NAME = "open-composer";
+const INSTALL_DIR = join(homedir(), ".open-composer");
+const BIN_DIR = join(homedir(), ".local", "bin");
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+interface UpgradeError {
+  readonly _tag: "UpgradeError";
+  readonly message: string;
+  readonly cause: unknown;
+}
+
+const makeUpgradeError = (params: {
+  readonly message: string;
+  readonly cause: unknown;
+}): UpgradeError => {
+  return {
+    _tag: "UpgradeError",
+    message: params.message,
+    cause: params.cause,
+  };
+};
+
+type InstallMethod = "npm" | "binary" | "unknown";
+
+interface InstallInfo {
+  method: InstallMethod;
+  binaryPath: string;
+}
+
+// -----------------------------------------------------------------------------
+// Command Builder
+// -----------------------------------------------------------------------------
+
+export function buildUpgradeCommand(): CommandBuilder<"upgrade"> {
+  return {
+    command: () => upgradeCommand,
+    metadata: {
+      name: "upgrade",
+      description: "Upgrade to the latest version",
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Detect how open-composer was installed by checking the binary path.
+ *
+ * npm global installs typically go to:
+ * - /usr/local/bin (macOS/Linux)
+ * - ~/.npm-global/bin
+ * - C:\Users\{user}\AppData\Roaming\npm (Windows)
+ *
+ * Binary installs go to:
+ * - ~/.local/bin
+ */
+async function detectInstallMethod(): Promise<InstallInfo> {
+  try {
+    // Get the path to the currently running binary
+    const binaryPath = process.argv[1];
+
+    if (!binaryPath) {
+      return { method: "unknown", binaryPath: "" };
+    }
+
+    // Resolve symlinks to get the actual binary location
+    const realBinaryPath = await realpath(binaryPath);
+
+    // Check if it's in typical npm global directories
+    if (
+      realBinaryPath.includes("/npm/") ||
+      realBinaryPath.includes("\\npm\\") ||
+      realBinaryPath.includes("/node_modules/") ||
+      realBinaryPath.includes("\\node_modules\\") ||
+      realBinaryPath.includes(".npm-global") ||
+      realBinaryPath.includes("/usr/local/lib/node_modules/")
+    ) {
+      return { method: "npm", binaryPath: realBinaryPath };
+    }
+
+    // Check if it's in ~/.local/bin or similar binary install locations
+    if (
+      realBinaryPath.includes(".local/bin") ||
+      realBinaryPath.includes(".open-composer")
+    ) {
+      return { method: "binary", binaryPath: realBinaryPath };
+    }
+
+    // Default to binary if we can't determine
+    return { method: "binary", binaryPath: realBinaryPath };
+  } catch {
+    return { method: "unknown", binaryPath: "" };
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Platform Detection
+// -----------------------------------------------------------------------------
+
+/**
+ * Detect the current platform and architecture
+ */
+function detectPlatform(): string {
+  const os = platform();
+  const cpuArch = arch();
+
+  let platformStr: string;
+  switch (os) {
+    case "linux":
+      platformStr = "linux";
+      break;
+    case "darwin":
+      platformStr = "macos";
+      break;
+    case "win32":
+      platformStr = "windows";
+      break;
+    default:
+      throw new Error(`Unsupported operating system: ${os}`);
+  }
+
+  let archStr: string;
+  switch (cpuArch) {
+    case "x64":
+      archStr = "x64";
+      break;
+    case "arm64":
+      archStr = "arm64";
+      break;
+    default:
+      throw new Error(`Unsupported architecture: ${cpuArch}`);
+  }
+
+  return `${platformStr}-${archStr}`;
+}
+
+/**
+ * Map platform string to GitHub release binary name
+ */
+function getBinaryName(platformStr: string): string {
+  switch (platformStr) {
+    case "linux-x64":
+      return "opencomposer-cli-linux-x64";
+    case "linux-arm64":
+      return "opencomposer-cli-linux-aarch64-musl";
+    case "macos-x64":
+      return "opencomposer-cli-darwin-x64";
+    case "macos-arm64":
+      return "opencomposer-cli-darwin-arm64";
+    case "windows-x64":
+      return "opencomposer-cli-win32-x64";
+    default:
+      throw new Error(`Unsupported platform: ${platformStr}`);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Upgrade Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Upgrade via npm - preserves the npm installation
+ */
+const upgradeViaNpm = (version: string): Effect.Effect<void, UpgradeError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const { spawn } = await import("bun");
+      const packageSpec = `${PACKAGE_NAME}@${version}`;
+
+      console.log(`Upgrading via npm to ${packageSpec}...`);
+
+      const proc = spawn(["npm", "install", "-g", packageSpec], {
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+
+      const exitCode = await proc.exited;
+
+      if (exitCode !== 0) {
+        throw new Error(`npm install failed with exit code ${exitCode}`);
+      }
+
+      console.log(`✓ Successfully upgraded via npm`);
+    },
+    catch: (error) => {
+      return makeUpgradeError({
+        message: `Failed to upgrade via npm: ${error instanceof Error ? error.message : String(error)}`,
+        cause: error,
+      });
+    },
+  });
+
+/**
+ * Download and install the binary from GitHub releases.
+ * Replaces the existing binary at its current location.
+ */
+const upgradeFromGitHub = (
+  version: string,
+  installInfo: InstallInfo,
+): Effect.Effect<void, UpgradeError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const platformStr = detectPlatform();
+      const binaryName = getBinaryName(platformStr);
+
+      // Determine target directory
+      const targetBinary =
+        installInfo.binaryPath || join(BIN_DIR, "open-composer");
+      const targetDir = dirname(targetBinary);
+
+      // Create directories
+      await mkdir(INSTALL_DIR, { recursive: true });
+      await mkdir(targetDir, { recursive: true });
+
+      // Download URL
+      const downloadUrl = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${PACKAGE_NAME}@${version}/${binaryName}.zip`;
+      const zipPath = join(INSTALL_DIR, `${binaryName}.zip`);
+
+      console.log(`Downloading from ${downloadUrl}...`);
+
+      // Download the binary
+      const response = await fetch(downloadUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download binary: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      // Write to file
+      await Bun.write(zipPath, buffer);
+
+      console.log("Extracting files...");
+
+      // Extract using unzip
+      const { spawn } = await import("bun");
+      const proc = spawn(["unzip", "-q", "-o", zipPath, "-d", INSTALL_DIR], {
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        throw new Error(
+          `Failed to extract binary: unzip exited with code ${exitCode}`,
+        );
+      }
+
+      // Move binary to target location (overwriting existing)
+      const extractedBinary = join(INSTALL_DIR, "open-composer");
+
+      // Remove old binary if it exists
+      try {
+        await rm(targetBinary, { force: true });
+      } catch {
+        // Ignore if doesn't exist
+      }
+
+      await rename(extractedBinary, targetBinary);
+      await chmod(targetBinary, 0o755);
+
+      // Cleanup
+      await rm(zipPath, { force: true });
+
+      console.log(`✓ Installed to ${targetBinary}`);
+    },
+    catch: (error) => {
+      return makeUpgradeError({
+        message: `Failed to upgrade binary: ${error instanceof Error ? error.message : String(error)}`,
+        cause: error,
+      });
+    },
+  });
+
+// -----------------------------------------------------------------------------
+// Options & Args
+// -----------------------------------------------------------------------------
+
+const checkOption = Options.boolean("check").pipe(
+  Options.withAlias("c"),
+  Options.withDescription("Check for updates without installing"),
+);
+
+const versionArg = Args.text({ name: "version" }).pipe(
+  Args.optional,
+  Args.withDescription("Specific version to upgrade to (optional)"),
+);
+
+// -----------------------------------------------------------------------------
+// Command Implementation
+// -----------------------------------------------------------------------------
+
+const upgradeCommand = Command.make("upgrade", {
+  check: checkOption,
+  version: versionArg,
+}).pipe(
+  Command.withDescription("Upgrade open-composer to the latest version"),
+  Command.withHandler(({ check, version }) =>
+    Effect.gen(function* () {
+      const versionValue = version?._tag === "Some" ? version.value : undefined;
+
+      yield* trackFeatureUsage("upgrade_command_started", {
+        check_only: check,
+        target_version: versionValue || "latest",
+      });
+
+      const releases = yield* GitHubReleases;
+
+      // Get latest version from GitHub
+      const latestVersion = yield* releases.getLatestVersion();
+      const currentVersion = CLI_VERSION;
+
+      yield* Console.log(`Current version: ${currentVersion}`);
+      yield* Console.log(`Latest version:  ${latestVersion}`);
+
+      const comparison = compareVersions(currentVersion, latestVersion);
+
+      if (comparison === 0) {
+        yield* Console.log("\n✓ You are already running the latest version!");
+        yield* trackFeatureUsage("upgrade_command_completed", {
+          already_latest: true,
+          version: currentVersion,
+        });
+        return;
+      }
+
+      if (comparison > 0) {
+        yield* Console.log(
+          "\n⚠ You are running a newer version than the latest release.",
+        );
+        yield* trackFeatureUsage("upgrade_command_completed", {
+          newer_than_latest: true,
+          current: currentVersion,
+          latest: latestVersion,
+        });
+        return;
+      }
+
+      // If check-only mode, just report the availability
+      if (check) {
+        yield* Console.log(`\n↑ A new version is available: ${latestVersion}`);
+        yield* Console.log(`  Run 'open-composer upgrade' to update.`);
+        yield* trackFeatureUsage("upgrade_command_completed", {
+          check_only: true,
+          update_available: true,
+          latest: latestVersion,
+        });
+        return;
+      }
+
+      // Detect installation method
+      const installInfo = yield* Effect.promise(() => detectInstallMethod());
+
+      yield* Console.log(`Detected installation method: ${installInfo.method}`);
+      if (installInfo.binaryPath) {
+        yield* Console.log(
+          `Current binary location: ${installInfo.binaryPath}`,
+        );
+      }
+
+      // Perform the upgrade
+      const targetVersion = versionValue || latestVersion;
+
+      yield* Console.log(`\nUpgrading to ${PACKAGE_NAME}@${targetVersion}...`);
+
+      // Use the appropriate upgrade method
+      if (installInfo.method === "npm") {
+        yield* Console.log(
+          "Using npm upgrade method to preserve your npm installation...",
+        );
+        yield* upgradeViaNpm(targetVersion);
+      } else {
+        yield* Console.log("Using binary upgrade method...");
+        yield* upgradeFromGitHub(targetVersion, installInfo);
+      }
+
+      yield* Console.log(
+        `\n✓ Successfully upgraded to version ${targetVersion}!`,
+      );
+      yield* Console.log("  Run 'open-composer --version' to verify.");
+
+      yield* trackFeatureUsage("upgrade_command_completed", {
+        success: true,
+        from_version: currentVersion,
+        to_version: targetVersion,
+        install_method: installInfo.method,
+      });
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.gen(function* () {
+          yield* trackFeatureUsage("upgrade_command_failed", {
+            error: String(error),
+          });
+          return yield* Effect.fail(error);
+        }),
+      ),
+      Effect.provide(
+        makeGitHubReleasesLive({
+          owner: GITHUB_OWNER,
+          repo: GITHUB_REPO,
+          packageName: PACKAGE_NAME,
+        }),
+      ),
+      Effect.withSpan("upgrade_command", {
+        attributes: {
+          check,
+          version: version?._tag === "Some" ? version.value : undefined,
+        },
+      }),
+    ),
+  ),
+);

--- a/apps/cli/tests/__snapshots__/cli.test.tsx.snap
+++ b/apps/cli/tests/__snapshots__/cli.test.tsx.snap
@@ -19,6 +19,7 @@ COMMANDS
   status            Show current status of agents, worktrees, and PRs
   telemetry         Manage telemetry and privacy settings
   tui               Launch the interactive TUI
+  upgrade           Upgrade to the latest version
 
 Run 'open-composer <command> --help' for more information on a specific command.
 "

--- a/apps/cli/tests/commands/upgrade.test.ts
+++ b/apps/cli/tests/commands/upgrade.test.ts
@@ -33,18 +33,21 @@ describe("upgrade command", () => {
   });
 
   describe("command options", () => {
-    test("should support check option", () => {
+    test("should have correct command builder structure", () => {
       const commandBuilder = buildUpgradeCommand();
-      const command = commandBuilder.command();
-      expect(command).toBeDefined();
-      // The check option is embedded in the command structure
+      expect(commandBuilder).toBeDefined();
+      expect(commandBuilder).toHaveProperty("command");
+      expect(commandBuilder).toHaveProperty("metadata");
+      expect(commandBuilder.metadata.name).toBe("upgrade");
+      expect(commandBuilder.metadata.description).toBe(
+        "Upgrade to the latest version",
+      );
     });
 
-    test("should support version argument", () => {
+    test("should export command function", () => {
       const commandBuilder = buildUpgradeCommand();
-      const command = commandBuilder.command();
-      expect(command).toBeDefined();
-      // The version argument is embedded in the command structure
+      expect(commandBuilder.command).toBeDefined();
+      expect(typeof commandBuilder.command).toBe("function");
     });
   });
 });

--- a/apps/cli/tests/commands/upgrade.test.ts
+++ b/apps/cli/tests/commands/upgrade.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { buildUpgradeCommand } from "../../src/commands/upgrade-command.js";
+
+describe("upgrade command", () => {
+  describe("command structure", () => {
+    test("should build upgrade command successfully", () => {
+      const commandBuilder = buildUpgradeCommand();
+      expect(commandBuilder).toBeDefined();
+      expect(commandBuilder.metadata).toBeDefined();
+      expect(commandBuilder.metadata.name).toBe("upgrade");
+      expect(commandBuilder.metadata.description).toBe(
+        "Upgrade to the latest version",
+      );
+    });
+
+    test("should have correct metadata", () => {
+      const commandBuilder = buildUpgradeCommand();
+      expect(commandBuilder.metadata.name).toBe("upgrade");
+      expect(commandBuilder.metadata.description).toContain("Upgrade");
+    });
+
+    test("should export command function", () => {
+      const commandBuilder = buildUpgradeCommand();
+      expect(commandBuilder.command).toBeDefined();
+      expect(typeof commandBuilder.command).toBe("function");
+    });
+
+    test("command should be callable", () => {
+      const commandBuilder = buildUpgradeCommand();
+      const command = commandBuilder.command();
+      expect(command).toBeDefined();
+    });
+  });
+
+  describe("command options", () => {
+    test("should support check option", () => {
+      const commandBuilder = buildUpgradeCommand();
+      const command = commandBuilder.command();
+      expect(command).toBeDefined();
+      // The check option is embedded in the command structure
+    });
+
+    test("should support version argument", () => {
+      const commandBuilder = buildUpgradeCommand();
+      const command = commandBuilder.command();
+      expect(command).toBeDefined();
+      // The version argument is embedded in the command structure
+    });
+  });
+});

--- a/apps/landing/src/app/install/route.ts
+++ b/apps/landing/src/app/install/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  // Redirect to the raw GitHub install script
+  // Serve the install script from a stable release tag
   const installScriptUrl =
     "https://raw.githubusercontent.com/shunkakinoki/open-composer/main/install.sh";
 
   try {
-    // Fetch the install script from GitHub
-    const response = await fetch(installScriptUrl);
+    // Fetch the install script from GitHub with timeout
+    const response = await fetch(installScriptUrl, {
+      signal: AbortSignal.timeout(10000), // 10 second timeout
+    });
 
     if (!response.ok) {
       return new NextResponse("Failed to fetch install script", {
@@ -24,8 +26,8 @@ export async function GET() {
         "Cache-Control": "public, max-age=300", // Cache for 5 minutes
       },
     });
-  } catch (error) {
-    console.error("Error fetching install script:", error);
+  } catch {
+    console.error("Error fetching install script");
     return new NextResponse("Error fetching install script", { status: 500 });
   }
 }

--- a/apps/landing/src/app/install/route.ts
+++ b/apps/landing/src/app/install/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  // Redirect to the raw GitHub install script
+  const installScriptUrl =
+    "https://raw.githubusercontent.com/shunkakinoki/open-composer/main/install.sh";
+
+  try {
+    // Fetch the install script from GitHub
+    const response = await fetch(installScriptUrl);
+
+    if (!response.ok) {
+      return new NextResponse("Failed to fetch install script", {
+        status: 500,
+      });
+    }
+
+    const script = await response.text();
+
+    // Return the script with appropriate headers
+    return new NextResponse(script, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=300", // Cache for 5 minutes
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching install script:", error);
+    return new NextResponse("Error fetching install script", { status: 500 });
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "apps/cli": {
       "name": "open-composer",
-      "version": "0.8.0",
+      "version": "0.8.3",
       "bin": {
         "oc": "./src/index.ts",
         "open-composer": "./src/index.ts",
@@ -99,6 +99,7 @@
         "@open-composer/gh": "workspace:*",
         "@open-composer/gh-pr": "workspace:*",
         "@open-composer/git": "workspace:*",
+        "@open-composer/git-releases": "workspace:*",
         "@open-composer/git-stack": "workspace:*",
         "@open-composer/git-worktrees": "workspace:*",
         "@open-composer/process-runner": "workspace:*",
@@ -238,6 +239,19 @@
     "packages/git": {
       "name": "@open-composer/git",
       "version": "0.1.1",
+      "dependencies": {
+        "effect": "^3.18.0",
+      },
+      "devDependencies": {
+        "@effect/language-service": "^0.41.1",
+        "@types/bun": "^1.2.23",
+        "@types/node": "^24.6.0",
+        "typescript": "^5.9.2",
+      },
+    },
+    "packages/git-releases": {
+      "name": "@open-composer/git-releases",
+      "version": "0.1.0",
       "dependencies": {
         "effect": "^3.18.0",
       },
@@ -608,6 +622,8 @@
     "@open-composer/gh-pr": ["@open-composer/gh-pr@workspace:packages/gh-pr"],
 
     "@open-composer/git": ["@open-composer/git@workspace:packages/git"],
+
+    "@open-composer/git-releases": ["@open-composer/git-releases@workspace:packages/git-releases"],
 
     "@open-composer/git-stack": ["@open-composer/git-stack@workspace:packages/git-stack"],
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Open Composer installation script
+# Usage: curl -fsSL https://opencomposer.ai/install | bash
+#
+
+set -e
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+
+REPO="shunkakinoki/open-composer"
+PACKAGE_NAME="open-composer"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.open-composer}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# -----------------------------------------------------------------------------
+# Helper Functions
+# -----------------------------------------------------------------------------
+
+info() {
+  echo -e "${BLUE}ℹ${NC} $1"
+}
+
+success() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+warn() {
+  echo -e "${YELLOW}⚠${NC} $1"
+}
+
+error() {
+  echo -e "${RED}✗${NC} $1"
+  exit 1
+}
+
+# Detect OS and Architecture
+detect_platform() {
+  local os arch
+
+  # Detect OS
+  case "$(uname -s)" in
+    Linux*)     os="linux" ;;
+    Darwin*)    os="macos" ;;
+    MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+    *)          error "Unsupported operating system: $(uname -s)" ;;
+  esac
+
+  # Detect architecture
+  case "$(uname -m)" in
+    x86_64|amd64)   arch="x64" ;;
+    aarch64|arm64)  arch="arm64" ;;
+    *)              error "Unsupported architecture: $(uname -m)" ;;
+  esac
+
+  echo "${os}-${arch}"
+}
+
+# Check if command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Check if npm is available
+check_npm() {
+  if command_exists npm; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Install via npm (preferred method)
+install_via_npm() {
+  info "Installing ${PACKAGE_NAME} via npm..."
+
+  if ! check_npm; then
+    error "npm is not installed. Please install Node.js and npm first."
+  fi
+
+  npm install -g "${PACKAGE_NAME}@latest" || error "Failed to install via npm"
+
+  success "Successfully installed ${PACKAGE_NAME} via npm!"
+}
+
+# Get the latest release version from GitHub
+get_latest_version() {
+  local version
+
+  if command_exists curl; then
+    version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | \
+      grep '"tag_name":' | \
+      sed -E 's/.*"([^"]+)".*/\1/' | \
+      sed "s/${PACKAGE_NAME}@//")
+  elif command_exists wget; then
+    version=$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | \
+      grep '"tag_name":' | \
+      sed -E 's/.*"([^"]+)".*/\1/' | \
+      sed "s/${PACKAGE_NAME}@//")
+  else
+    error "Neither curl nor wget is available. Please install one of them."
+  fi
+
+  if [ -z "$version" ]; then
+    error "Failed to fetch the latest version"
+  fi
+
+  echo "$version"
+}
+
+# Map platform to GitHub release binary name
+get_binary_name() {
+  local platform="$1"
+
+  case "$platform" in
+    linux-x64)       echo "opencomposer-cli-linux-x64" ;;
+    linux-arm64)     echo "opencomposer-cli-linux-aarch64-musl" ;;
+    macos-x64)       echo "opencomposer-cli-darwin-x64" ;;
+    macos-arm64)     echo "opencomposer-cli-darwin-arm64" ;;
+    windows-x64)     echo "opencomposer-cli-win32-x64" ;;
+    *)               error "Unsupported platform: $platform" ;;
+  esac
+}
+
+# Download and install from GitHub release
+install_from_github() {
+  local version="$1"
+  local platform="$2"
+  local binary_name
+  binary_name=$(get_binary_name "$platform")
+
+  info "Installing ${PACKAGE_NAME}@${version} from GitHub releases..."
+
+  # Create installation directory
+  mkdir -p "$INSTALL_DIR"
+  mkdir -p "$BIN_DIR"
+
+  # Download binary from GitHub releases
+  local download_url="https://github.com/${REPO}/releases/download/${PACKAGE_NAME}@${version}/${binary_name}.zip"
+  local zip_path="${INSTALL_DIR}/${binary_name}.zip"
+
+  info "Downloading from ${download_url}..."
+
+  if command_exists curl; then
+    curl -fsSL "$download_url" -o "$zip_path" || error "Failed to download binary"
+  elif command_exists wget; then
+    wget -q "$download_url" -O "$zip_path" || error "Failed to download binary"
+  else
+    error "Neither curl nor wget is available"
+  fi
+
+  # Extract binary
+  info "Extracting files..."
+  if command_exists unzip; then
+    unzip -q -o "$zip_path" -d "$INSTALL_DIR" || error "Failed to extract binary"
+  else
+    error "unzip is not available. Please install unzip."
+  fi
+
+  # Find and move the binary
+  local extracted_binary="${INSTALL_DIR}/open-composer"
+  local target_binary="${BIN_DIR}/open-composer"
+
+  if [ -f "$extracted_binary" ]; then
+    mv "$extracted_binary" "$target_binary" || error "Failed to move binary"
+    chmod +x "$target_binary" || error "Failed to make binary executable"
+    success "Installed ${PACKAGE_NAME} to ${target_binary}"
+  else
+    error "Binary not found in extracted package"
+  fi
+
+  # Cleanup
+  rm -f "$zip_path"
+}
+
+# Add to PATH if needed
+update_path() {
+  local shell_config=""
+
+  # Detect shell configuration file
+  if [ -n "$BASH_VERSION" ]; then
+    shell_config="$HOME/.bashrc"
+  elif [ -n "$ZSH_VERSION" ]; then
+    shell_config="$HOME/.zshrc"
+  elif [ -f "$HOME/.profile" ]; then
+    shell_config="$HOME/.profile"
+  fi
+
+  # Check if BIN_DIR is in PATH
+  if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+    warn "$BIN_DIR is not in your PATH"
+
+    if [ -n "$shell_config" ]; then
+      info "Adding $BIN_DIR to PATH in $shell_config"
+      echo "" >> "$shell_config"
+      echo "# Open Composer" >> "$shell_config"
+      echo "export PATH=\"\$PATH:$BIN_DIR\"" >> "$shell_config"
+      success "Added $BIN_DIR to PATH. Please restart your shell or run: source $shell_config"
+    else
+      warn "Please add $BIN_DIR to your PATH manually"
+    fi
+  fi
+}
+
+# Verify installation
+verify_installation() {
+  info "Verifying installation..."
+
+  if command_exists open-composer; then
+    local version
+    version=$(open-composer --version 2>&1 | head -n 1 || echo "unknown")
+    success "open-composer is installed and available in PATH"
+    info "Version: $version"
+  else
+    warn "open-composer command not found in PATH"
+    info "You may need to restart your shell or add $BIN_DIR to your PATH"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Main Installation Flow
+# -----------------------------------------------------------------------------
+
+main() {
+  echo ""
+  info "Open Composer Installer"
+  echo ""
+
+  # Detect platform
+  local platform
+  platform=$(detect_platform)
+  info "Detected platform: $platform"
+
+  # Check installation method
+  if check_npm; then
+    info "Found npm, using npm for installation (recommended)"
+    install_via_npm
+  else
+    warn "npm not found, falling back to manual installation"
+
+    # Get latest version
+    local version
+    version=$(get_latest_version)
+    info "Latest version: $version"
+
+    # Install from GitHub releases
+    install_from_github "$version" "$platform"
+
+    # Update PATH
+    update_path
+  fi
+
+  echo ""
+  verify_installation
+  echo ""
+  success "Installation complete!"
+  info "Run 'open-composer --help' to get started"
+  echo ""
+}
+
+# Run main installation
+main

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "sort-package-json:check": "sort-package-json package.json */*/package.json --check",
     "sort-package-json:fix": "sort-package-json package.json */*/package.json",
     "test": "turbo run test",
+    "test:coverage": "turbo run test -- --coverage",
+    "test:update": "turbo run test -- --update-snapshots",
     "type-check": "turbo run type-check",
     "version": "bun run changeset:version"
   },

--- a/packages/git-releases/README.md
+++ b/packages/git-releases/README.md
@@ -1,0 +1,118 @@
+# @open-composer/git-releases
+
+GitHub Releases API client and version comparison utilities built with Effect.
+
+## Features
+
+- 🚀 Fetch latest releases from GitHub repositories
+- 📦 Version comparison utilities
+- 🛡️ Type-safe with Effect-based error handling
+- ✅ Fully tested
+
+## Philosophy
+
+This package focuses solely on GitHub Releases API interactions and version comparison logic. Package upgrade/installation logic is intentionally kept separate (in the CLI) to maintain clean separation of concerns.
+
+## Installation
+
+```bash
+bun add @open-composer/git-releases
+```
+
+## Usage
+
+### GitHub Releases API
+
+```typescript
+import { GitHubReleases, makeGitHubReleasesLive } from "@open-composer/git-releases";
+import * as Effect from "effect/Effect";
+
+const program = Effect.gen(function* () {
+  const releases = yield* GitHubReleases;
+
+  // Get latest release
+  const latest = yield* releases.getLatestRelease();
+  console.log(latest.version);
+
+  // Get latest version string
+  const version = yield* releases.getLatestVersion();
+  console.log(version);
+
+  // List releases with pagination
+  const allReleases = yield* releases.listReleases({ page: 1, perPage: 10 });
+
+  // Get specific release by tag
+  const specific = yield* releases.getReleaseByTag("v1.0.0");
+});
+
+const layer = makeGitHubReleasesLive({
+  owner: "shunkakinoki",
+  repo: "open-composer",
+  packageName: "open-composer", // optional - removes this prefix from version strings
+});
+
+Effect.runPromise(program.pipe(Effect.provide(layer)));
+```
+
+### Version Comparison
+
+```typescript
+import { compareVersions, isUpdateAvailable } from "@open-composer/git-releases";
+
+// Compare two versions
+const result = compareVersions("1.0.0", "2.0.0"); // returns -1
+const isEqual = compareVersions("1.0.0", "1.0.0"); // returns 0
+const isNewer = compareVersions("2.0.0", "1.0.0"); // returns 1
+
+// Check if update is available
+if (isUpdateAvailable("1.0.0", "2.0.0")) {
+  console.log("Update available!");
+}
+```
+
+## API
+
+### Types
+
+#### `ReleaseInfo`
+```typescript
+interface ReleaseInfo {
+  readonly tagName: string;
+  readonly version: string;
+  readonly name: string;
+  readonly body: string;
+  readonly url: string;
+  readonly publishedAt: string;
+  readonly assets: ReadonlyArray<ReleaseAsset>;
+}
+```
+
+#### `GitHubReleasesService`
+```typescript
+interface GitHubReleasesService {
+  readonly getLatestRelease: () => Effect.Effect<ReleaseInfo, GitHubReleasesError>;
+  readonly getLatestVersion: () => Effect.Effect<string, GitHubReleasesError>;
+  readonly getReleaseByTag: (tag: string) => Effect.Effect<ReleaseInfo, GitHubReleasesError>;
+  readonly listReleases: (params?: {
+    readonly page?: number;
+    readonly perPage?: number;
+  }) => Effect.Effect<ReadonlyArray<ReleaseInfo>, GitHubReleasesError>;
+}
+```
+
+### Version Utilities
+
+- `compareVersions(current: string, target: string): VersionComparison` - Compare two semver versions
+- `isUpdateAvailable(current: string, latest: string): boolean` - Check if update is available
+- `isNewerThanLatest(current: string, latest: string): boolean` - Check if current is newer
+- `isLatestVersion(current: string, latest: string): boolean` - Check if versions match
+
+## Testing
+
+```bash
+bun test
+```
+
+## License
+
+MIT

--- a/packages/git-releases/package.json
+++ b/packages/git-releases/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@open-composer/git-releases",
+  "version": "0.1.0",
+  "repository": "https://github.com/shunkakinoki/open-composer",
+  "license": "MIT",
+  "author": "Shun Kakinoki",
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src/**/*",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target=node",
+    "dev": "bun run ./src/index.ts",
+    "test": "bun test",
+    "test:coverage": "bun test --coverage",
+    "test:update-snapshot": "bun test --updateSnapshot",
+    "test:watch": "bun test --watch",
+    "type-check": "tsc -b tsconfig.json"
+  },
+  "dependencies": {
+    "effect": "^3.18.0"
+  },
+  "devDependencies": {
+    "@effect/language-service": "^0.41.1",
+    "@types/bun": "^1.2.23",
+    "@types/node": "^24.6.0",
+    "typescript": "^5.9.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/git-releases/src/core.ts
+++ b/packages/git-releases/src/core.ts
@@ -1,0 +1,305 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface ReleaseInfo {
+  readonly tagName: string;
+  readonly version: string;
+  readonly name: string;
+  readonly body: string;
+  readonly url: string;
+  readonly publishedAt: string;
+  readonly assets: ReadonlyArray<ReleaseAsset>;
+}
+
+export interface ReleaseAsset {
+  readonly name: string;
+  readonly url: string;
+  readonly downloadUrl: string;
+  readonly size: number;
+  readonly contentType: string;
+}
+
+export interface GitHubReleasesError {
+  readonly _tag: "GitHubReleasesError";
+  readonly message: string;
+  readonly cause: unknown;
+  readonly statusCode?: number | undefined;
+}
+
+const makeGitHubReleasesError = (params: {
+  readonly message: string;
+  readonly cause: unknown;
+  readonly statusCode?: number | undefined;
+}): GitHubReleasesError => {
+  const result: GitHubReleasesError = {
+    _tag: "GitHubReleasesError",
+    message: params.message,
+    cause: params.cause,
+  };
+  if (params.statusCode !== undefined) {
+    return { ...result, statusCode: params.statusCode };
+  }
+  return result;
+};
+
+export interface GitHubReleasesConfig {
+  readonly owner: string;
+  readonly repo: string;
+  readonly packageName?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Service
+// -----------------------------------------------------------------------------
+
+export interface GitHubReleasesService {
+  readonly getLatestRelease: () => Effect.Effect<
+    ReleaseInfo,
+    GitHubReleasesError
+  >;
+  readonly getLatestVersion: () => Effect.Effect<string, GitHubReleasesError>;
+  readonly getReleaseByTag: (
+    tag: string,
+  ) => Effect.Effect<ReleaseInfo, GitHubReleasesError>;
+  readonly listReleases: (params?: {
+    readonly page?: number;
+    readonly perPage?: number;
+  }) => Effect.Effect<ReadonlyArray<ReleaseInfo>, GitHubReleasesError>;
+}
+
+export const GitHubReleases = Context.GenericTag<GitHubReleasesService>(
+  "@open-composer/git-releases/GitHubReleases",
+);
+
+// -----------------------------------------------------------------------------
+// Implementation
+// -----------------------------------------------------------------------------
+
+function parseReleaseInfo(
+  data: {
+    tag_name: string;
+    name: string;
+    body: string;
+    html_url: string;
+    published_at: string;
+    assets: Array<{
+      name: string;
+      url: string;
+      browser_download_url: string;
+      size: number;
+      content_type: string;
+    }>;
+  },
+  packageName?: string,
+): ReleaseInfo {
+  const tagName = data.tag_name;
+  const version = packageName
+    ? tagName.replace(`${packageName}@`, "")
+    : tagName;
+
+  return {
+    tagName,
+    version,
+    name: data.name,
+    body: data.body,
+    url: data.html_url,
+    publishedAt: data.published_at,
+    assets: data.assets.map((asset) => ({
+      name: asset.name,
+      url: asset.url,
+      downloadUrl: asset.browser_download_url,
+      size: asset.size,
+      contentType: asset.content_type,
+    })),
+  };
+}
+
+export const makeGitHubReleasesLive = (
+  config: GitHubReleasesConfig,
+): Layer.Layer<GitHubReleasesService> =>
+  Layer.succeed(
+    GitHubReleases,
+    GitHubReleases.of({
+      getLatestRelease: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const url = `https://api.github.com/repos/${config.owner}/${config.repo}/releases/latest`;
+            const response = await fetch(url, {
+              headers: {
+                Accept: "application/vnd.github.v3+json",
+              },
+            });
+
+            if (!response.ok) {
+              throw {
+                statusCode: response.status,
+                message: `Failed to fetch latest release: ${response.statusText}`,
+              };
+            }
+
+            const data = (await response.json()) as {
+              tag_name: string;
+              name: string;
+              body: string;
+              html_url: string;
+              published_at: string;
+              assets: Array<{
+                name: string;
+                url: string;
+                browser_download_url: string;
+                size: number;
+                content_type: string;
+              }>;
+            };
+            return parseReleaseInfo(data, config.packageName);
+          },
+          catch: (error) => {
+            const err = error as { statusCode?: number; message?: string };
+            return makeGitHubReleasesError({
+              message:
+                err.message ||
+                `Failed to fetch latest release: ${String(error)}`,
+              cause: error,
+              statusCode: err.statusCode ?? undefined,
+            });
+          },
+        }),
+
+      getLatestVersion: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const url = `https://api.github.com/repos/${config.owner}/${config.repo}/releases/latest`;
+            const response = await fetch(url, {
+              headers: {
+                Accept: "application/vnd.github.v3+json",
+              },
+            });
+
+            if (!response.ok) {
+              throw {
+                statusCode: response.status,
+                message: `Failed to fetch latest release: ${response.statusText}`,
+              };
+            }
+
+            const data = (await response.json()) as {
+              tag_name: string;
+            };
+            const tagName = data.tag_name;
+            const version = config.packageName
+              ? tagName.replace(`${config.packageName}@`, "")
+              : tagName;
+            return version;
+          },
+          catch: (error) => {
+            const err = error as { statusCode?: number; message?: string };
+            return makeGitHubReleasesError({
+              message:
+                err.message ||
+                `Failed to fetch latest version: ${String(error)}`,
+              cause: error,
+              statusCode:
+                err.statusCode !== undefined ? err.statusCode : undefined,
+            });
+          },
+        }),
+
+      getReleaseByTag: (tag: string) =>
+        Effect.tryPromise({
+          try: async () => {
+            const url = `https://api.github.com/repos/${config.owner}/${config.repo}/releases/tags/${tag}`;
+            const response = await fetch(url, {
+              headers: {
+                Accept: "application/vnd.github.v3+json",
+              },
+            });
+
+            if (!response.ok) {
+              throw {
+                statusCode: response.status,
+                message: `Failed to fetch release for tag ${tag}: ${response.statusText}`,
+              };
+            }
+
+            const data = (await response.json()) as {
+              tag_name: string;
+              name: string;
+              body: string;
+              html_url: string;
+              published_at: string;
+              assets: Array<{
+                name: string;
+                url: string;
+                browser_download_url: string;
+                size: number;
+                content_type: string;
+              }>;
+            };
+            return parseReleaseInfo(data, config.packageName);
+          },
+          catch: (error) => {
+            const err = error as { statusCode?: number; message?: string };
+            return makeGitHubReleasesError({
+              message:
+                err.message ||
+                `Failed to fetch release for tag ${tag}: ${String(error)}`,
+              cause: error,
+              statusCode: err.statusCode ?? undefined,
+            });
+          },
+        }),
+
+      listReleases: (params) =>
+        Effect.tryPromise({
+          try: async () => {
+            const page = params?.page || 1;
+            const perPage = params?.perPage || 30;
+            const url = `https://api.github.com/repos/${config.owner}/${config.repo}/releases?page=${page}&per_page=${perPage}`;
+            const response = await fetch(url, {
+              headers: {
+                Accept: "application/vnd.github.v3+json",
+              },
+            });
+
+            if (!response.ok) {
+              throw {
+                statusCode: response.status,
+                message: `Failed to list releases: ${response.statusText}`,
+              };
+            }
+
+            const data = (await response.json()) as Array<{
+              tag_name: string;
+              name: string;
+              body: string;
+              html_url: string;
+              published_at: string;
+              assets: Array<{
+                name: string;
+                url: string;
+                browser_download_url: string;
+                size: number;
+                content_type: string;
+              }>;
+            }>;
+            return data.map((item) =>
+              parseReleaseInfo(item, config.packageName),
+            );
+          },
+          catch: (error) => {
+            const err = error as { statusCode?: number; message?: string };
+            return makeGitHubReleasesError({
+              message:
+                err.message || `Failed to list releases: ${String(error)}`,
+              cause: error,
+              statusCode: err.statusCode ?? undefined,
+            });
+          },
+        }),
+    }),
+  );

--- a/packages/git-releases/src/index.ts
+++ b/packages/git-releases/src/index.ts
@@ -1,0 +1,23 @@
+// GitHub Releases API
+export {
+  GitHubReleases,
+  type GitHubReleasesConfig,
+  type GitHubReleasesError,
+  type GitHubReleasesService,
+  makeGitHubReleasesLive,
+  type ReleaseAsset,
+  type ReleaseInfo,
+} from "./core.js";
+
+// Version comparison
+export {
+  compareVersions,
+  compareVersionsEffect,
+  isLatestVersion,
+  isLatestVersionEffect,
+  isNewerThanLatest,
+  isNewerThanLatestEffect,
+  isUpdateAvailable,
+  isUpdateAvailableEffect,
+  type VersionComparison,
+} from "./version.js";

--- a/packages/git-releases/src/version.ts
+++ b/packages/git-releases/src/version.ts
@@ -18,8 +18,24 @@ export function compareVersions(
   current: string,
   target: string,
 ): VersionComparison {
-  const currentParts = current.split(".").map(Number);
-  const targetParts = target.split(".").map(Number);
+  // Remove 'v' prefix if present
+  const normalizeVersion = (version: string) =>
+    version.startsWith("v") ? version.slice(1) : version;
+
+  const currentNormalized = normalizeVersion(current);
+  const targetNormalized = normalizeVersion(target);
+
+  // Basic semver regex validation (major.minor.patch)
+  const semverRegex = /^\d+(\.\d+)*(\.\d+)*$/;
+  if (
+    !semverRegex.test(currentNormalized) ||
+    !semverRegex.test(targetNormalized)
+  ) {
+    throw new Error(`Invalid version format. Expected format: X.Y.Z or vX.Y.Z`);
+  }
+
+  const currentParts = currentNormalized.split(".").map(Number);
+  const targetParts = targetNormalized.split(".").map(Number);
 
   for (let i = 0; i < Math.max(currentParts.length, targetParts.length); i++) {
     const currentPart = currentParts[i] || 0;

--- a/packages/git-releases/src/version.ts
+++ b/packages/git-releases/src/version.ts
@@ -1,0 +1,85 @@
+import * as Effect from "effect/Effect";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export type VersionComparison = -1 | 0 | 1;
+
+// -----------------------------------------------------------------------------
+// Version Comparison
+// -----------------------------------------------------------------------------
+
+/**
+ * Compare two semantic versions.
+ * @returns -1 if current < target, 0 if equal, 1 if current > target
+ */
+export function compareVersions(
+  current: string,
+  target: string,
+): VersionComparison {
+  const currentParts = current.split(".").map(Number);
+  const targetParts = target.split(".").map(Number);
+
+  for (let i = 0; i < Math.max(currentParts.length, targetParts.length); i++) {
+    const currentPart = currentParts[i] || 0;
+    const targetPart = targetParts[i] || 0;
+
+    if (currentPart < targetPart) return -1;
+    if (currentPart > targetPart) return 1;
+  }
+
+  return 0;
+}
+
+/**
+ * Check if an update is available for the given current version.
+ */
+export const isUpdateAvailable = (
+  currentVersion: string,
+  latestVersion: string,
+): boolean => compareVersions(currentVersion, latestVersion) === -1;
+
+/**
+ * Check if the current version is newer than the latest release.
+ */
+export const isNewerThanLatest = (
+  currentVersion: string,
+  latestVersion: string,
+): boolean => compareVersions(currentVersion, latestVersion) === 1;
+
+/**
+ * Check if the current version is the latest.
+ */
+export const isLatestVersion = (
+  currentVersion: string,
+  latestVersion: string,
+): boolean => compareVersions(currentVersion, latestVersion) === 0;
+
+// -----------------------------------------------------------------------------
+// Effect-based API
+// -----------------------------------------------------------------------------
+
+export const compareVersionsEffect = (
+  current: string,
+  target: string,
+): Effect.Effect<VersionComparison> =>
+  Effect.sync(() => compareVersions(current, target));
+
+export const isUpdateAvailableEffect = (
+  currentVersion: string,
+  latestVersion: string,
+): Effect.Effect<boolean> =>
+  Effect.sync(() => isUpdateAvailable(currentVersion, latestVersion));
+
+export const isNewerThanLatestEffect = (
+  currentVersion: string,
+  latestVersion: string,
+): Effect.Effect<boolean> =>
+  Effect.sync(() => isNewerThanLatest(currentVersion, latestVersion));
+
+export const isLatestVersionEffect = (
+  currentVersion: string,
+  latestVersion: string,
+): Effect.Effect<boolean> =>
+  Effect.sync(() => isLatestVersion(currentVersion, latestVersion));

--- a/packages/git-releases/tests/core.test.ts
+++ b/packages/git-releases/tests/core.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import { GitHubReleases, makeGitHubReleasesLive } from "../src/core.js";
+
+describe("GitHubReleases service", () => {
+  // Use a real public repository for testing
+  const testConfig = {
+    owner: "shunkakinoki",
+    repo: "open-composer",
+    packageName: "open-composer",
+  };
+
+  describe("getLatestRelease", () => {
+    test("should fetch the latest release", async () => {
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        const release = yield* service.getLatestRelease();
+
+        expect(release).toBeDefined();
+        expect(release.tagName).toBeDefined();
+        expect(release.version).toBeDefined();
+        expect(release.name).toBeDefined();
+        expect(release.url).toBeDefined();
+        expect(release.publishedAt).toBeDefined();
+        expect(Array.isArray(release.assets)).toBe(true);
+
+        return release;
+      });
+
+      const result = await Effect.runPromise(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(testConfig))),
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    test("should handle package name prefix in tag", async () => {
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        const release = yield* service.getLatestRelease();
+
+        // Version should not have the package name prefix
+        expect(release.version).not.toContain("@");
+      });
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(testConfig))),
+      );
+    });
+  });
+
+  describe("getLatestVersion", () => {
+    test("should return the latest version string", async () => {
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        const version = yield* service.getLatestVersion();
+
+        expect(typeof version).toBe("string");
+        expect(version.length).toBeGreaterThan(0);
+        // Should match semver format (basic check)
+        expect(version).toMatch(/^\d+\.\d+\.\d+/);
+      });
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(testConfig))),
+      );
+    });
+  });
+
+  describe("listReleases", () => {
+    test("should list releases", async () => {
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        const releases = yield* service.listReleases({ perPage: 5 });
+
+        expect(Array.isArray(releases)).toBe(true);
+        expect(releases.length).toBeGreaterThan(0);
+        expect(releases.length).toBeLessThanOrEqual(5);
+
+        // Check first release structure
+        const firstRelease = releases[0];
+        expect(firstRelease?.tagName).toBeDefined();
+        expect(firstRelease?.version).toBeDefined();
+      });
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(testConfig))),
+      );
+    });
+
+    test("should support pagination", async () => {
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        const page1 = yield* service.listReleases({ page: 1, perPage: 2 });
+        const page2 = yield* service.listReleases({ page: 2, perPage: 2 });
+
+        expect(page1.length).toBeLessThanOrEqual(2);
+        expect(page2.length).toBeLessThanOrEqual(2);
+
+        // Pages should be different (if enough releases exist)
+        if (page1.length > 0 && page2.length > 0) {
+          expect(page1[0]?.tagName).not.toBe(page2[0]?.tagName);
+        }
+      });
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(testConfig))),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    test("should handle invalid repository", async () => {
+      const invalidConfig = {
+        owner: "nonexistent",
+        repo: "nonexistent-repo-12345",
+      };
+
+      const program = Effect.gen(function* () {
+        const service = yield* GitHubReleases;
+        yield* service.getLatestRelease();
+      });
+
+      const result = Effect.runPromiseExit(
+        program.pipe(Effect.provide(makeGitHubReleasesLive(invalidConfig))),
+      );
+
+      const exit = await result;
+      expect(exit._tag).toBe("Failure");
+    });
+  });
+});

--- a/packages/git-releases/tests/version.test.ts
+++ b/packages/git-releases/tests/version.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareVersions,
+  isLatestVersion,
+  isNewerThanLatest,
+  isUpdateAvailable,
+} from "../src/version.js";
+
+describe("version comparison", () => {
+  describe("compareVersions", () => {
+    test("should return -1 when current version is less than target", () => {
+      expect(compareVersions("1.0.0", "2.0.0")).toBe(-1);
+      expect(compareVersions("1.5.0", "1.6.0")).toBe(-1);
+      expect(compareVersions("1.0.1", "1.0.2")).toBe(-1);
+    });
+
+    test("should return 0 when versions are equal", () => {
+      expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+      expect(compareVersions("2.5.3", "2.5.3")).toBe(0);
+    });
+
+    test("should return 1 when current version is greater than target", () => {
+      expect(compareVersions("2.0.0", "1.0.0")).toBe(1);
+      expect(compareVersions("1.6.0", "1.5.0")).toBe(1);
+      expect(compareVersions("1.0.2", "1.0.1")).toBe(1);
+    });
+
+    test("should handle versions with different lengths", () => {
+      expect(compareVersions("1.0", "1.0.0")).toBe(0);
+      expect(compareVersions("1.0.0", "1.0")).toBe(0);
+      expect(compareVersions("1.1", "1.0.5")).toBe(1);
+      expect(compareVersions("1.0.5", "1.1")).toBe(-1);
+    });
+
+    test("should handle pre-release versions (treating them as numbers)", () => {
+      // Note: These tests assume simple numeric comparison
+      expect(compareVersions("1.0.0", "1.0.1")).toBe(-1);
+    });
+  });
+
+  describe("isUpdateAvailable", () => {
+    test("should return true when update is available", () => {
+      expect(isUpdateAvailable("1.0.0", "2.0.0")).toBe(true);
+      expect(isUpdateAvailable("1.5.0", "1.6.0")).toBe(true);
+    });
+
+    test("should return false when no update is available", () => {
+      expect(isUpdateAvailable("2.0.0", "1.0.0")).toBe(false);
+      expect(isUpdateAvailable("1.0.0", "1.0.0")).toBe(false);
+    });
+  });
+
+  describe("isNewerThanLatest", () => {
+    test("should return true when current is newer", () => {
+      expect(isNewerThanLatest("2.0.0", "1.0.0")).toBe(true);
+      expect(isNewerThanLatest("1.6.0", "1.5.0")).toBe(true);
+    });
+
+    test("should return false when current is not newer", () => {
+      expect(isNewerThanLatest("1.0.0", "2.0.0")).toBe(false);
+      expect(isNewerThanLatest("1.0.0", "1.0.0")).toBe(false);
+    });
+  });
+
+  describe("isLatestVersion", () => {
+    test("should return true when versions match", () => {
+      expect(isLatestVersion("1.0.0", "1.0.0")).toBe(true);
+      expect(isLatestVersion("2.5.3", "2.5.3")).toBe(true);
+    });
+
+    test("should return false when versions don't match", () => {
+      expect(isLatestVersion("1.0.0", "2.0.0")).toBe(false);
+      expect(isLatestVersion("2.0.0", "1.0.0")).toBe(false);
+    });
+  });
+});

--- a/packages/git-releases/tsconfig.json
+++ b/packages/git-releases/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    {
+      "path": "tsconfig.src.json"
+    }
+  ]
+}

--- a/packages/git-releases/tsconfig.src.json
+++ b/packages/git-releases/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "types": ["node", "bun-types"],
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": ".",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
feat(landing): implement GET route for fetching install script from GitHub

feat(install): create installation script for Open Composer with npm and GitHub release support

docs(git-releases): add README with features, installation, usage, and API documentation

chore(git-releases): initialize package.json for GitHub releases API client

feat(git-releases): implement core functionality for fetching GitHub releases and version comparison

test(git-releases): add tests for GitHub releases service and version comparison utilities

chore(git-releases): configure TypeScript for the GitHub releases package

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new CLI upgrade command with GitHub release integration and a one-line install script to make installing and updating Open Composer simple. Also introduced a git-releases package for fetching releases and comparing versions, with tests and CI to verify installation and upgrades.

- **New Features**
  - Upgrade command: supports --check and specific versions, auto-detects npm vs binary installs, fetches binaries from GitHub releases, and logs telemetry.
  - New package @open-composer/git-releases: GitHub Releases API client and version comparison utilities, with unit tests.
  - Quick install: added install.sh and a /install route that serves the script; README updated with install/upgrade instructions.
  - CI: added an install-e2e job to run install.sh and verify the open-composer command.

- **Refactors**
  - Simplified option building and path imports in git-worktree and run commands; fixed component import path.

<!-- End of auto-generated description by cubic. -->

