### PR TITLE
Run echo command in terminal

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,3 @@
 {
-  "setup-worktree": [
-    "make setup"
-  ]
+  "setup-worktree": ["make setup"]
 }

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "make setup"
+  ]
+}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -32,19 +32,14 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
       - name: Setup Bun
         uses: shunkakinoki/actions/.github/actions/setup-bun@83febae34a6e97704047144dd36b0681c5759d79
-      - name: Set Environment Variables
+      - name: Detect if Changeset Release
         run: |
-          echo "PUBLISH_PACKAGES=${PUBLISH_PACKAGES}" >> $GITHUB_ENV
-          echo "GITHUB_SHA=${{ github.sha }}" >> $GITHUB_ENV
-          echo "GITHUB_REF=${{ github.ref }}" >> $GITHUB_ENV
-          echo "GITHUB_HEAD_REF=${{ github.head_ref }}" >> $GITHUB_ENV
-          echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
-          echo "GITHUB_EVENT_NAME=${{ github.event_name }}" >> $GITHUB_ENV
-          echo "GITHUB_EVENT_PATH=${{ github.event_path }}" >> $GITHUB_ENV
-          echo "GITHUB_EVENT_NUMBER=${{ github.event_number }}" >> $GITHUB_ENV
-          echo "GITHUB_REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-        env:
-          PUBLISH_PACKAGES: true
+          LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          if [[ "$LAST_COMMIT_MESSAGE" == *"Version Packages"* ]] || [[ "$LAST_COMMIT_MESSAGE" == *"Release Version"* ]]; then
+            echo "PUBLISH_PACKAGES=true" >> $GITHUB_ENV
+          else
+            echo "PUBLISH_PACKAGES=false" >> $GITHUB_ENV
+          fi
       - name: Run Changesets
         uses: shunkakinoki/actions/.github/actions/changesets@83febae34a6e97704047144dd36b0681c5759d79
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,34 @@
 .DEFAULT_GOAL := help
 
 # ====================================================================================
+# Development
+# ====================================================================================
+
+.PHONY: install
+install: bun-install ## Install dependencies
+
+.PHONY: build
+build: bun-build ## Build the project
+
+.PHONY: setup
+setup: install build ## Install dependencies and build the project
+
+# ====================================================================================
+# Bun
+# ====================================================================================
+
+.PHONY: bun-install
+bun-install: ## Install dependencies using bun
+	bun install
+
+.PHONY: bun-build
+bun-build: ## Build the project using bun
+	bun run build
+
+.PHONY: bun-setup
+bun-setup: bun-install bun-build ## Install dependencies and build the project
+
+# ====================================================================================
 # HELP
 # ====================================================================================
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "make setup"
+  }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized project setup with Make targets and Bun support, and updated CI to publish packages only on release commits.

- **New Features**
  - Makefile with install, build, and setup targets using Bun.
  - conductor.json script to run setup via `make setup`.
  - .cursor/worktrees.json to run `make setup` on worktree creation.

- **CI**
  - Changesets workflow now sets PUBLISH_PACKAGES based on the last commit message containing “Version Packages” or “Release Version”.

<!-- End of auto-generated description by cubic. -->

