### PR TITLE
fix: update file path in release.yml for artifact upload (#233)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
-          file: ./apps/cli/dist/open-composer-*.zip
+          file: apps/cli/dist/open-composer-*.zip
           tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           overwrite: true
   release-latest:


### PR DESCRIPTION
- Changed the file path in the GitHub Actions workflow from a relative path to a more concise format for the CLI artifact upload.
