### PR TITLE
fix: update CLI binary naming for consistency

### DIFF
--- a/.changeset/chilly-apples-sneeze.md
+++ b/.changeset/chilly-apples-sneeze.md
@@ -1,0 +1,7 @@
+---
+"@shunkakinoki/open-composer-cli": patch
+---
+
+Fix binary naming consistency in CLI installation scripts
+
+Update postinstall.mjs and preinstall.mjs to use "open-composer" instead of "opencomposer" for binary names, ensuring consistency with the project naming convention.

--- a/.changeset/chilly-apples-sneeze.md
+++ b/.changeset/chilly-apples-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"@shunkakinoki/open-composer-cli": patch
+"open-composer": patch
 ---
 
 Fix binary naming consistency in CLI installation scripts

--- a/apps/cli/scripts/postinstall.mjs
+++ b/apps/cli/scripts/postinstall.mjs
@@ -74,7 +74,7 @@ function findBinary() {
 
 function installBinary() {
   const isWindows = os.platform() === "win32";
-  const binaryName = isWindows ? "opencomposer.exe" : "opencomposer";
+  const binaryName = isWindows ? "open-composer.exe" : "open-composer";
   const destinationBinary = path.join(binDir, binaryName);
 
   // Skip if we already have a real binary (helps local development reuse builds)
@@ -115,10 +115,10 @@ function installBinary() {
 
     // On Windows, ensure the .cmd wrapper exists and points to the .exe
     if (isWindows) {
-      const cmdScriptPath = path.join(binDir, "opencomposer.cmd");
+      const cmdScriptPath = path.join(binDir, "open-composer.cmd");
       const cmdContent = `@ECHO OFF\n"${destinationBinary}" %*\n`;
       fs.writeFileSync(cmdScriptPath, cmdContent, { encoding: "utf8" });
-      console.log("Updated opencomposer.cmd wrapper for Windows");
+      console.log("Updated open-composer.cmd wrapper for Windows");
     }
   } else {
     console.error(`No binary found at ${binaryPath}`);

--- a/apps/cli/scripts/preinstall.mjs
+++ b/apps/cli/scripts/preinstall.mjs
@@ -18,13 +18,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function main() {
   if (os.platform() !== "win32") {
     console.log(
-      "Non-Windows platform detected, skipping preinstall opencomposer.cmd",
+      "Non-Windows platform detected, skipping preinstall open-composer.cmd",
     );
     return;
   }
 
-  console.log("Windows detected: Setting up opencomposer.cmd");
-  const cmdScriptPath = path.join(__dirname, "bin", "opencomposer.cmd");
+  console.log("Windows detected: Setting up open-composer.cmd");
+  const cmdScriptPath = path.join(__dirname, "bin", "open-composer.cmd");
 
   // ---------------------------------------------------------------------------
   // Ensure the .cmd wrapper exists (create a minimal one if needed)
@@ -34,7 +34,7 @@ function main() {
   const cmdContent = `@ECHO OFF\nREM Placeholder - will be updated by postinstall.mjs\n`;
   fs.writeFileSync(cmdScriptPath, cmdContent, { encoding: "utf8" });
   console.log(
-    "Created placeholder opencomposer.cmd wrapper for Windows (will be updated by postinstall)",
+    "Created placeholder open-composer.cmd wrapper for Windows (will be updated by postinstall)",
   );
 }
 


### PR DESCRIPTION
## Changes Made
- Change binary name from 'opencomposer' to 'open-composer' in postinstall.mjs
- Update binary name in preinstall.mjs for Windows .cmd wrapper
- Align binary naming with project name convention

## Technical Details
- Modified postinstall.mjs to use consistent binary naming
- Updated preinstall.mjs Windows wrapper setup
- Ensures binary names match the project naming convention
- No functional changes to installation logic

## Testing
- All pre-commit hooks pass (Biome formatting, linting, TypeScript checks)
- Build completes successfully
- Manual verification of binary naming consistency
- No breaking changes to existing functionality

🤖 Generated with Cursor by Claude
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized the CLI binary name to "open-composer" across installation scripts. Aligns with the project name and fixes the Windows .cmd wrapper.

<!-- End of auto-generated description by cubic. -->

