### PR TITLE
Update binary path references for open-composer consistency

### DIFF
--- a/apps/cli/bin/open-composer
+++ b/apps/cli/bin/open-composer
@@ -31,21 +31,21 @@ else
     *) arch="$(uname -m)" ;;
   esac
 
-  binary="opencomposer"
-  [ "$platform" = "win32" ] && binary="opencomposer.exe"
+  binary="open-composer"
+  [ "$platform" = "win32" ] && binary="open-composer.exe"
 
   # ---------------------------------------------------------------------------
-  # Assume binary is in ./apps/cli/node_modules/opencomposer-<platform>-<arch>/bin/
+  # Assume binary is in ./apps/cli/node_modules/@open-composer/cli-<platform>-<arch>/bin/
   # ---------------------------------------------------------------------------
 
-  resolved="$(dirname "$0")/../node_modules/opencomposer-${platform}-${arch}/bin/${binary}"
+  resolved="$(dirname "$0")/../node_modules/@open-composer/cli-${platform}-${arch}/bin/${binary}"
 
   # ---------------------------------------------------------------------------
   # Check if the binary exists
   # ---------------------------------------------------------------------------
 
   if [ ! -f "$resolved" ]; then
-    echo "Error: Binary not found for opencomposer-${platform}-${arch}. Please ensure the correct version is installed." >&2
+    echo "Error: Binary not found for @open-composer/cli-${platform}-${arch}. Please ensure the correct version is installed." >&2
     exit 1
   fi
 fi

--- a/apps/cli/bin/open-composer.cmd
+++ b/apps/cli/bin/open-composer.cmd
@@ -29,15 +29,15 @@ REM ----------------------------------------------------------------------------
 REM Set binary path
 REM -----------------------------------------------------------------------------
 
-SET "binary=opencomposer.exe"
-SET "resolved=%~dp0..\node_modules\opencomposer-windows-!arch!\bin\!binary!"
+SET "binary=open-composer.exe"
+SET "resolved=%~dp0..\node_modules\@open-composer\cli-windows-!arch!\bin\!binary!"
 
 REM -----------------------------------------------------------------------------
 REM Check if binary exists
 REM -----------------------------------------------------------------------------
 
 IF NOT EXIST "!resolved!" (
-    ECHO Error: Binary not found for opencomposer-windows-!arch!. Please ensure the correct version is installed. >&2
+    ECHO Error: Binary not found for @open-composer/cli-windows-!arch!. Please ensure the correct version is installed. >&2
     EXIT /B 1
 )
 


### PR DESCRIPTION
Ensure consistency in binary path references for open-composer across different platforms. This change updates the paths to reflect the new package structure.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update CLI launcher scripts to use the new @open-composer/cli-<platform>-<arch> package and the open-composer(.exe) binary name. This fixes path resolution across macOS, Linux, and Windows.

- **Bug Fixes**
  - Pointed bin paths to @open-composer/cli-<platform>-<arch>.
  - Renamed binary from opencomposer(.exe) to open-composer(.exe).
  - Updated error messages to match the new package and binary names.

<!-- End of auto-generated description by cubic. -->

