### PR TITLE
fix: resolve Windows CLI installation path issues

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -50,14 +50,7 @@ jobs:
           max_attempts: 10
           command: npm install -g ${{ github.event.release.tag_name || github.event.inputs.tag || 'open-composer@latest' }}
       - name: Verify opencomposer command
-        if: matrix.os != 'windows-latest'
         run: open-composer --version
-        shell: bash
-      - name: Verify opencomposer command (Windows)
-        if: matrix.os == 'windows-latest'
-        continue-on-error: true
-        run: open-composer --version
-        shell: cmd
   install-e2e-script:
     if: (github.event.release.tag_name && startsWith(github.event.release.tag_name, 'open-composer@')) || (github.event.inputs.tag && startsWith(github.event.inputs.tag, 'open-composer@')) || github.event_name == 'schedule'
     runs-on: ${{ matrix.os }}

--- a/apps/cli/scripts/postinstall.mjs
+++ b/apps/cli/scripts/postinstall.mjs
@@ -116,7 +116,7 @@ function installBinary() {
     // On Windows, ensure the .cmd wrapper exists and points to the .exe
     if (isWindows) {
       const cmdScriptPath = path.join(binDir, "open-composer.cmd");
-      const cmdContent = `@ECHO OFF\n"${destinationBinary}" %*\n`;
+      const cmdContent = `@ECHO OFF\r\n"%~dp0\\open-composer.exe" %*\r\n`;
       fs.writeFileSync(cmdScriptPath, cmdContent, { encoding: "utf8" });
       console.log("Updated open-composer.cmd wrapper for Windows");
     }


### PR DESCRIPTION
## Summary
- Fix Windows CLI installation by improving binary path resolution
- Update .cmd wrapper to search up directory tree for platform-specific binary package
- Use relative paths in postinstall-generated wrapper instead of absolute paths

## Changes
- **apps/cli/bin/open-composer.cmd**: Search node_modules tree for `@open-composer/cli-win32-{arch}` package instead of hardcoded relative path
- **apps/cli/scripts/postinstall.mjs**: Generate .cmd wrapper with `%~dp0` (relative path) and Windows line endings
- **.github/workflows/install.yml**: Simplify verification to use same command on all platforms (remove `continue-on-error` for Windows)

## Test plan
- [ ] Test Windows installation via `npm install -g open-composer`
- [ ] Verify `open-composer --version` works on Windows
- [ ] Ensure macOS/Linux installations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)