### PR TITLE
feat: add Homebrew tap automation with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,15 @@ jobs:
           file: apps/cli/dist/open-composer-*.zip
           tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           overwrite: true
+      - name: Update Homebrew Tap
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --skip=validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
   release-latest:
     needs: release-upload
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+# GoReleaser configuration for Homebrew tap
+# https://goreleaser.com/customization/homebrew/
+
+version: 2
+
+# Since binaries are already built by Bun in the release workflow,
+# we use GoReleaser only for Homebrew tap management
+builds:
+  - skip: true
+
+# Configure Homebrew tap
+brews:
+  - name: open-composer
+
+    # Target repository for the tap
+    repository:
+      owner: shunkakinoki
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
+    # Download strategy - fetch pre-built binaries from GitHub releases
+    download_strategy: CurlDownloadStrategy
+
+    # Install script to extract and install the binary
+    install: |
+      arch = Hardware::CPU.arch.to_s
+      os = OS.mac? ? "darwin" : "linux"
+
+      # Map architecture to match binary naming
+      arch_map = {
+        "x86_64" => "x64",
+        "arm64" => "arm64"
+      }
+
+      binary_arch = arch_map[arch] || arch
+      binary_name = "open-composer-cli-#{os}-#{binary_arch}"
+
+      # Download and extract the binary
+      system "curl", "-fsSL", "-o", "#{binary_name}.zip",
+        "https://github.com/shunkakinoki/open-composer/releases/download/#{version}/#{binary_name}.zip"
+      system "unzip", "-q", "#{binary_name}.zip"
+
+      # Install the binary
+      bin.install "#{binary_name}/bin/open-composer"
+
+      # Create symlinks for alternate names
+      bin.install_symlink bin/"open-composer" => "oc"
+      bin.install_symlink bin/"open-composer" => "opencomposer"
+
+    # Test to verify installation
+    test: |
+      system "#{bin}/open-composer", "--version"
+
+    # Metadata
+    homepage: "https://github.com/shunkakinoki/open-composer"
+    description: "Open Composer CLI - AI-powered development workflow tool"
+    license: "MIT"
+
+    # Use the package name and version from the release tag
+    url_template: "https://github.com/shunkakinoki/open-composer/releases/download/{{ .Tag }}/open-composer-cli-darwin-{{ .Arch }}.zip"
+
+    # Only include macOS since Homebrew is primarily for macOS
+    skip_upload: auto


### PR DESCRIPTION
## Summary

- Added `.goreleaser.yml` configuration for automated Homebrew tap management
- Updated `.github/workflows/release.yml` to include GoReleaser step for tap updates
- Enables one-command installation: `brew install shunkakinoki/tap/open-composer`

## Changes

### `.goreleaser.yml`
- Configured to target `shunkakinoki/homebrew-tap` repository
- Downloads pre-built binaries from GitHub releases
- Auto-generates and updates Homebrew formula
- Creates symlinks for `oc` and `opencomposer` commands
- Supports both macOS architectures (x64 and arm64)

### `.github/workflows/release.yml`
- Added GoReleaser action step after binary upload
- Configured with `HOMEBREW_TAP_GITHUB_TOKEN` for tap repository access
- Runs on every release to keep formula up-to-date

## Prerequisites

Before merging, ensure:
1. Create GitHub repository: `shunkakinoki/homebrew-tap`
2. Add `HOMEBREW_TAP_GITHUB_TOKEN` secret to this repository with `repo` permissions

## Testing

On the next release, GoReleaser will automatically:
- Generate `Formula/open-composer.rb` in the tap repository
- Update the formula with latest version and download URLs
- Users can then install via: `brew install shunkakinoki/tap/open-composer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automates Homebrew tap updates with GoReleaser so users can install the CLI via brew install shunkakinoki/tap/open-composer. The formula is updated on every release.

- **New Features**
  - Added .goreleaser.yml to generate and update the tap in shunkakinoki/homebrew-tap.
  - Release workflow now runs GoReleaser after uploading binaries to update the formula.
  - Installs prebuilt zips and creates oc and opencomposer symlinks.
  - Supports macOS x64 and arm64.

- **Migration**
  - Create the shunkakinoki/homebrew-tap repository.
  - Add a PAT_TOKEN secret with repo scope; used for GITHUB_TOKEN and HOMEBREW_TAP_GITHUB_TOKEN.

<!-- End of auto-generated description by cubic. -->

