### PR TITLE
fix: improve Windows npm install and install.sh error handling

### DIFF
--- a/apps/cli/bin/open-composer
+++ b/apps/cli/bin/open-composer
@@ -1,9 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 
 # -----------------------------------------------------------------------------
 # Determine binary path
 # -----------------------------------------------------------------------------
+
+# Get the script's directory
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 # Use OPENCOMPOSER_BIN_PATH if set, otherwise determine binary path
 if [ -n "$OPENCOMPOSER_BIN_PATH" ]; then
@@ -35,16 +38,16 @@ else
   [ "$platform" = "win32" ] && binary="open-composer.exe"
 
   # ---------------------------------------------------------------------------
-  # Assume binary is in ./apps/cli/node_modules/@open-composer/cli-<platform>-<arch>/bin/
+  # Look for binary in multiple locations
   # ---------------------------------------------------------------------------
 
-  resolved="$(dirname "$0")/../node_modules/@open-composer/cli-${platform}-${arch}/bin/${binary}"
-
-  # ---------------------------------------------------------------------------
-  # Check if the binary exists
-  # ---------------------------------------------------------------------------
-
-  if [ ! -f "$resolved" ]; then
+  # First check if binary exists in the same directory (postinstall places it here)
+  if [ -f "$script_dir/$binary" ]; then
+    resolved="$script_dir/$binary"
+  # Then check in node_modules (development mode)
+  elif [ -f "$script_dir/../node_modules/@open-composer/cli-${platform}-${arch}/bin/${binary}" ]; then
+    resolved="$script_dir/../node_modules/@open-composer/cli-${platform}-${arch}/bin/${binary}"
+  else
     echo "Error: Binary not found for @open-composer/cli-${platform}-${arch}. Please ensure the correct version is installed." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Fix Windows npm global install by updating bin/open-composer to check for binary in the same directory first (where postinstall places it)
- Improve install.sh error handling to gracefully fall back to npm when GitHub releases fail
- Change shebang from `#!/bin/sh` to `#!/usr/bin/env sh` for better portability
- Add GITHUB_TOKEN support to install.sh workflow step

## Changes

### apps/cli/bin/open-composer
- Updated to look for binary in the same directory first (where postinstall script places it)
- Added fallback to node_modules for development mode
- Changed shebang to `#!/usr/bin/env sh` for better compatibility

### install.sh
- Changed error handling in `get_latest_version()` to return error code instead of exiting
- Updated main installation flow to gracefully fall back to npm when GitHub releases fail
- Improved error messages and workflow

### .github/workflows/install.yml
- Added GITHUB_TOKEN to install.sh script step

## Test plan

- [x] Windows: npm global install should work without `/bin/sh.exe` error
- [x] macOS: install.sh should fall back to npm when GitHub releases fail
- [ ] Verify install workflow passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Windows npm global install errors and makes install.sh more resilient by falling back to npm when GitHub releases aren’t available. Also improves portability and CI reliability.

- **Bug Fixes**
  - Resolve CLI binary path by checking the script directory first, with a dev fallback to node_modules.
  - install.sh now returns an error from get_latest_version and gracefully falls back to npm when GitHub fetch/installation fails; adds install verification and clearer messages.
  - Switch shebang to `#!/usr/bin/env sh` for better portability.
  - CI workflow passes GITHUB_TOKEN to install.sh to support authenticated GitHub API calls.

<!-- End of auto-generated description by cubic. -->

