### PR TITLE
Invalid value in GitHub workflow file

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -69,7 +69,6 @@ jobs:
           timeout_seconds: 30
           max_attempts: 10
           command: bash install.sh
-        shell: bash
       - name: Verify open-composer command after script install
         run: |
           export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the invalid "shell: bash" key from the install workflow to fix GitHub Actions validation and ensure the retry step runs properly. The retry action already uses "command: bash install.sh", so the extra shell setting caused a workflow error.

<!-- End of auto-generated description by cubic. -->

