### PR TITLE
fix: skip archives in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,13 @@ version: 2
 builds:
   - skip: true
 
+# Skip archive creation since binaries are pre-built
+archives:
+  - id: skip-archives
+    format: binary
+
 # Configure Homebrew tap
-brews:
+homebrew:
   - name: open-composer
 
     # Target repository for the tap


### PR DESCRIPTION
## Summary
- Add archives section with `format: binary` to skip archive creation
- Replace deprecated `brews` with `homebrew`
- Fixes error: "no linux/macos archives found matching goos=[darwin linux]"

## Context
The GoReleaser workflow was failing because it was trying to create archives when builds are skipped. Since binaries are pre-built by Bun in the release workflow, GoReleaser only needs to manage the Homebrew tap without creating archives.

## Changes
- Added `archives` section with `format: binary` to explicitly skip archive generation
- Updated from deprecated `brews` to `homebrew` configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix GoReleaser failures by skipping archives and using the new Homebrew config. Binaries are built by Bun, so GoReleaser only publishes the tap; this resolves "no linux/macos archives found matching goos=[darwin linux]".

<!-- End of auto-generated description by cubic. -->

