### PR TITLE
fix: resolve CLI version tag error

### DIFF
--- a/.changeset/free-shirts-train.md
+++ b/.changeset/free-shirts-train.md
@@ -1,0 +1,5 @@
+---
+"open-composer": patch
+---
+
+Add bump release

--- a/apps/cli/src/lib/version.ts
+++ b/apps/cli/src/lib/version.ts
@@ -17,17 +17,4 @@ function readVersion(): string {
   }
 }
 
-// Create a version string class that reads fresh each time
-class VersionString {
-  toString() {
-    return readVersion();
-  }
-  valueOf() {
-    return readVersion();
-  }
-  [Symbol.toPrimitive](hint: string) {
-    return readVersion();
-  }
-}
-
-export const CLI_VERSION = new VersionString() as any as string;
+export const CLI_VERSION = readVersion();


### PR DESCRIPTION
## Summary
- Fixed `undefined is not an object (evaluating 'self2._tag')` error when running `open-composer --version`
- Changed `CLI_VERSION` from a custom `VersionString` class to a plain string

## Problem
The `CLI_VERSION` was using a custom class with `toString()`, `valueOf()`, and `Symbol.toPrimitive()` methods. When @effect/cli tried to serialize the version for the `--version` flag, it expected a primitive value but received a custom object without the required Effect `_tag` property, causing the error.

## Solution
Simplified `CLI_VERSION` to be a plain string by calling `readVersion()` directly, which resolves the serialization issue with @effect/cli.

## Test plan
- [x] Run `bun run apps/cli/src/index.ts --version` - returns version correctly
- [x] CI install tests should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the --version command crash in open-composer by exporting CLI_VERSION as a plain string so @effect/cli can serialize it correctly. Running open-composer --version now returns the version without errors.

- **Bug Fixes**
  - Replaced the VersionString wrapper with readVersion() to avoid “undefined is not an object (evaluating 'self2._tag')” during version flag handling.

<!-- End of auto-generated description by cubic. -->

