### PR TITLE
fix: use version.generated.ts for CLI version to work in bundled code

### DIFF
--- a/apps/cli/scripts/prepublish.ts
+++ b/apps/cli/scripts/prepublish.ts
@@ -10,7 +10,8 @@ import { $ } from "bun";
 console.log("Generating version file...");
 await $`bun run scripts/generate-version.ts`;
 
-import { CLI_VERSION } from "../src/lib/version.js";
+// Import version after generating the file (dynamic import to avoid module resolution errors)
+const { CLI_VERSION } = await import("../src/lib/version.js");
 
 // -----------------------------------------------------------------------------
 // Set the flags

--- a/apps/cli/src/lib/version.generated.d.ts
+++ b/apps/cli/src/lib/version.generated.d.ts
@@ -1,0 +1,3 @@
+// TypeScript declaration for generated version file
+// The actual .ts file is generated during build and is git-ignored
+export declare const CLI_VERSION: string;

--- a/apps/cli/src/lib/version.ts
+++ b/apps/cli/src/lib/version.ts
@@ -1,20 +1,4 @@
-// Read version from package.json directly
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-function readVersion(): string {
-  try {
-    const packageJsonPath = join(__dirname, "../../package.json");
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-    return packageJson.version || "0.0.0";
-  } catch {
-    // Fallback to default version if package.json can't be read
-    return "0.0.0";
-  }
-}
-
-export const CLI_VERSION = readVersion();
+// Export version from generated file
+// The version.generated.ts file is created during the build process
+// and contains the version from package.json
+export { CLI_VERSION } from "./version.generated.js";

--- a/apps/cli/tests/build/version-integration.test.ts
+++ b/apps/cli/tests/build/version-integration.test.ts
@@ -166,4 +166,27 @@ describe.skipIf(process.env.CI === "true")("version integration in build process
     const distIndexPath = join(distPath, "index.js");
     expect(existsSync(distIndexPath)).toBe(true);
   });
+
+  test("built binary should return correct version with --version flag", async () => {
+    const testVersion = "4.5.6-beta.1";
+
+    // Update package.json with test version
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    packageJson.version = testVersion;
+    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf8");
+
+    // Run the build process
+    const buildResult = await execAsync("bun", ["run", "build"], join(__dirname, "../.."));
+    expect(buildResult.code).toBe(0);
+
+    // Execute the built binary with --version
+    const distIndexPath = join(distPath, "index.js");
+    const versionResult = await execAsync("bun", [distIndexPath, "--version"], join(__dirname, "../.."));
+
+    // Check that the version command succeeded
+    expect(versionResult.code).toBe(0);
+
+    // Check that the output contains the correct version
+    expect(versionResult.stdout.trim()).toBe(testVersion);
+  });
 });

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -1,12 +1,12 @@
 {
   "extends": ["//"],
   "tasks": {
-    "test": {
-      "dependsOn": ["build", "^build"]
-    },
     "prepublishOnly": {
       "dependsOn": ["^build"],
       "env": ["PUBLISH_PACKAGES", "RELEASE_ZIP_FILES", "GITHUB_SHA"]
+    },
+    "test": {
+      "dependsOn": ["^build", "build"]
     }
   }
 }

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "test": {
+      "dependsOn": ["build", "^build"]
+    },
     "prepublishOnly": {
       "dependsOn": ["^build"],
       "env": ["PUBLISH_PACKAGES", "RELEASE_ZIP_FILES", "GITHUB_SHA"]


### PR DESCRIPTION
## Summary

Fixes the issue where `open-composer --version` returns `0.0.0` instead of the actual package version when running the bundled binary.

## Root Cause

The `apps/cli/src/lib/version.ts` file was attempting to read the version from `package.json` at runtime using a relative path (`../../package.json`). When the CLI was bundled, this path became invalid because the dist bundle doesn't have access to the original package.json file structure, causing it to fall back to the default `0.0.0` value.

## Changes

- **Updated `apps/cli/src/lib/version.ts`**: Changed to export from `version.generated.ts` instead of reading `package.json` at runtime
- **Added `apps/cli/src/lib/version.generated.d.ts`**: TypeScript declaration file for type checking when the generated file doesn't exist
- **Added integration test**: New test in `apps/cli/tests/build/version-integration.test.ts` that verifies the built binary returns the correct version with `--version` flag

## How It Works

1. During build, the `generate-version.ts` script reads `package.json` and creates `version.generated.ts` with the version string
2. `version.ts` imports and re-exports `CLI_VERSION` from the generated file
3. When bundled, the generated version is included in the bundle, making it available at runtime
4. The `.d.ts` file allows TypeScript to compile without errors when the generated file doesn't exist

## Test Plan

- ✅ All existing tests pass (255 pass, 3 skip)
- ✅ New integration test verifies binary `--version` returns correct version
- ✅ Type checking passes with the `.d.ts` declaration file
- ✅ Manually tested: `bun dist/index.js --version` returns `0.8.13` (not `0.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the CLI --version output in bundled builds by reading the version from a generated file at build time. The binary now reports the real package version instead of 0.0.0.

- **Bug Fixes**
  - version.ts now re-exports CLI_VERSION from version.generated.ts created during build.
  - Added version.generated.d.ts for TypeScript type checking before generation.
  - Added an integration test to verify the built binary prints the correct version.

<!-- End of auto-generated description by cubic. -->

