### PR TITLE
fix: update GoReleaser config to use 'brews' field for v2 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ archives:
     format: binary
 
 # Configure Homebrew tap
-homebrew:
+brews:
   - name: open-composer
 
     # Target repository for the tap


### PR DESCRIPTION
## Summary
- Fixed GoReleaser configuration error by renaming `homebrew` field to `brews` for v2 compatibility

## Details
The `homebrew` field was deprecated and renamed to `brews` in GoReleaser v2. This was causing the release workflow to fail with:
```
yaml: unmarshal errors:
  line 17: field homebrew not found in type config.Project
```

## Changes
- Updated `.goreleaser.yml` line 17 from `homebrew:` to `brews:`

## Test plan
- [x] GoReleaser config syntax is now valid for v2
- [ ] Verify release workflow succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated GoReleaser config to use the v2 brews field instead of deprecated homebrew. This fixes CI release failures when generating the Homebrew tap.

<!-- End of auto-generated description by cubic. -->

