### PR TITLE
fix: configure GoReleaser to skip archive validation for Homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,19 +3,28 @@
 
 version: 2
 
-# Since binaries are already built by Bun in the release workflow,
-# we use GoReleaser only for Homebrew tap management
+# Disable all build-related features since binaries are pre-built by Bun
 builds:
   - skip: true
 
-# Skip archive creation since binaries are pre-built
 archives:
-  - id: skip-archives
-    format: binary
+  - format: binary
+
+checksum:
+  disable: true
+
+snapshot:
+  version_template: "{{ .Tag }}"
 
 # Configure Homebrew tap
-brews:
+# NOTE: This formula uses a custom install script that downloads pre-built
+# binaries from GitHub releases, so it doesn't depend on GoReleaser's archives
+homebrew:
   - name: open-composer
+
+    # Skip archive dependencies since we use custom install script
+    ids: []
+    skip_upload: auto
 
     # Target repository for the tap
     repository:


### PR DESCRIPTION
## Summary
- Fix GoReleaser configuration to resolve "no linux/macos archives found" error
- Add `ids: []` to Homebrew formula config to skip archive validation since we use a custom install script
- Update deprecated `brews` field to `homebrew` for GoReleaser v2 compatibility
- Disable checksum generation as it's not needed for custom install approach

## Context
The GoReleaser action was failing because it expected to find archives for generating the Homebrew formula, but our workflow uses pre-built binaries from Bun instead of GoReleaser's build system. The custom install script in the Homebrew formula downloads binaries directly from GitHub releases, so GoReleaser doesn't need to validate or reference any archives.

## Test plan
- [ ] Verify GoReleaser action succeeds in release workflow
- [ ] Confirm Homebrew formula is generated correctly in tap repository
- [ ] Test Homebrew installation works with the generated formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Configure GoReleaser to generate the Homebrew formula without validating archives, fixing the “no linux/macos archives found” failure. Uses our custom install script that pulls pre-built Bun binaries from GitHub releases.

- **Bug Fixes**
  - Skip builds and simplify archives to format: binary.
  - Update to GoReleaser v2 `homebrew` config; set `ids: []` and `skip_upload: auto` to bypass archive validation.
  - Disable checksum and use tag-based snapshot version.

<!-- End of auto-generated description by cubic. -->

