### PR TITLE
feat: lean telemetry service implementation

### DIFF
--- a/.changeset/cruel-clubs-shout.md
+++ b/.changeset/cruel-clubs-shout.md
@@ -1,0 +1,5 @@
+---
+"open-composer": patch
+---
+
+Lean telemetry service

--- a/apps/cli/src/services/telemetry-service.ts
+++ b/apps/cli/src/services/telemetry-service.ts
@@ -3,15 +3,10 @@ import type { TelemetryConfig } from "@open-composer/config";
 import { Context, Effect, Layer } from "effect";
 import { PostHog } from "posthog-node";
 import { CLI_VERSION } from "../lib/version.js";
-import type { ConfigServiceInterface } from "./config-service.js";
 import { ConfigService, ConfigLive } from "./config-service.js";
 
 // Get or create a persistent anonymous user ID using the config system
-function getOrCreateAnonymousId(): Effect.Effect<
-  string,
-  never,
-  ConfigService
-> {
+function getOrCreateAnonymousId() {
   return Effect.gen(function* () {
     const configService = yield* ConfigService;
     const config = yield* configService.getConfig();


### PR DESCRIPTION
## Summary

- Simplified the telemetry service implementation
- Removed unused type import in telemetry service
- Added changeset for patch release

This PR implements a leaner telemetry service that reduces complexity while maintaining all existing functionality. The changes include removing an unnecessary type import and making the getOrCreateAnonymousId function more concise.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Leaned up the CLI telemetry service to reduce complexity with no behavior changes. Removed an unused type import and simplified getOrCreateAnonymousId; added a changeset for a patch release.

<!-- End of auto-generated description by cubic. -->

