### PR TITLE
Error installing open-composer with brew

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -74,7 +74,7 @@ class OpenComposer < Formula
                   "#{os}-#{arch}"
                 end
 
-    binary_dir = "open-composer-cli-#{os_suffix}"
+    binary_dir = "@open-composer/cli-#{os_suffix}"
 
     bin.install "#{binary_dir}/bin/open-composer"
     bin.install_symlink bin/"open-composer" => "oc"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Homebrew install errors by pointing the formula to the correct CLI archive directory. Brew now installs open-composer and the "oc" symlink as expected.

- **Bug Fixes**
  - Set binary_dir to "@open-composer/cli-#{os_suffix}" to match the release archive structure.

<!-- End of auto-generated description by cubic. -->

