### PR TITLE
Upgrade error in open-composer

### DIFF
--- a/apps/cli/src/commands/upgrade-command.ts
+++ b/apps/cli/src/commands/upgrade-command.ts
@@ -143,7 +143,7 @@ function detectPlatform(): string {
       platformStr = "linux";
       break;
     case "darwin":
-      platformStr = "macos";
+      platformStr = "darwin";
       break;
     case "win32":
       platformStr = "windows";
@@ -176,9 +176,9 @@ function getBinaryName(platformStr: string): string {
       return "open-composer-cli-linux-x64";
     case "linux-arm64":
       return "open-composer-cli-linux-aarch64-musl";
-    case "macos-x64":
+    case "darwin-x64":
       return "open-composer-cli-darwin-x64";
-    case "macos-arm64":
+    case "darwin-arm64":
       return "open-composer-cli-darwin-arm64";
     case "windows-x64":
       return "open-composer-cli-win32-x64";
@@ -297,11 +297,11 @@ const upgradeFromGitHub = (
       });
 
       // Move binary to target location (overwriting existing)
-      // The binary is extracted to a nested path in the zip: open-composer/cli-${platformStr}/bin/opencomposer[.exe]
-      const packageDir = `open-composer/cli-${platformStr}`;
+      // The binary is extracted to a nested path in the zip: @open-composer/cli-${platformStr}/bin/open-composer[.exe]
+      const packageDir = `@open-composer/cli-${platformStr}`;
       const extractedBinaryName = platformStr.startsWith("windows")
-        ? "opencomposer.exe"
-        : "opencomposer";
+        ? "open-composer.exe"
+        : "open-composer";
       const extractedBinary = join(
         INSTALL_DIR,
         packageDir,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes CLI upgrade failures by aligning platform names, asset paths, and binary filenames with the GitHub release structure. Prevents upgrade errors on macOS and other platforms.

- **Bug Fixes**
  - Use "darwin" instead of "macos" for platform detection and asset mapping.
  - Map to "darwin-x64" and "darwin-arm64" binaries.
  - Update zip extraction path to "@open-composer/cli-${platformStr}".
  - Rename binaries to "open-composer" and "open-composer.exe".

<!-- End of auto-generated description by cubic. -->

